### PR TITLE
PBI AB#329 - Integrar Party UI en combate para selección de cambio y ejecución mediante BattleSwitchChoice/BattleSwitchHandler

### DIFF
--- a/Scenes/Battle/ui/BattleUI.tscn
+++ b/Scenes/Battle/ui/BattleUI.tscn
@@ -8,6 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://brvsn2vfev6ng" path="res://Scenes/UI/MessageBox/MessageBox.tscn" id="5_alpup"]
 [ext_resource type="PackedScene" uid="uid://dauokklht8873" path="res://Scenes/Battle/ui/MoveMenu.tscn" id="6_x8cud"]
 [ext_resource type="StyleBox" uid="uid://ci1q4xtpco246" path="res://Resources/UI/MessageBox/Battle Styles/HGSS_BattleMessageBox_Style.tres" id="7_f6frr"]
+[ext_resource type="PackedScene" uid="uid://btgemydvaapwr" path="res://Scenes/UI/PartyUI.tscn" id="11_partyui"]
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_8fm4l"]
 
@@ -45,6 +46,10 @@ layout_mode = 1
 theme_override_styles/panel = ExtResource("7_f6frr")
 
 [node name="MovesMenu" parent="." unique_id=1305048248 instance=ExtResource("6_x8cud")]
+visible = false
+layout_mode = 1
+
+[node name="PartyUI" parent="." unique_id=1668194001 instance=ExtResource("11_partyui")]
 visible = false
 layout_mode = 1
 

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -1,5 +1,19 @@
 extends Node2D
 
+const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
+
+@export_group("Equipos de prueba")
+## Tamaño del party del jugador (1–6). En doble solo 2 salen al campo; el resto queda en banca para cambios.
+@export_range(1, 6) var test_player_party_size: int = 6
+## Tamaño del party del entrenador rival (1–6) cuando se use singleTrainerBattle / trainers en escena.
+@export_range(1, 6) var test_trainer_party_size: int = 6
+
+const WILD_PARTY_SINGLE: int = 1
+const WILD_PARTY_DOUBLE: int = 2
+
+# Instanciado solo al ejecutar esta escena en solitario (F6); en juego normal ya existe vía Main.
+var _bootstrapped_display_manager: DisplayManager = null
+
 #Battlers
 @onready var player: Battler = $Player
 @onready var singleTrainer: Battler = $SingleTrainer
@@ -8,6 +22,9 @@ extends Node2D
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
+	if not await _ensure_display_manager():
+		return
+	_setup_test_battler_parties()
 	# Lanzar combates en bucle para testing continuo
 	while true:
 		if randi() % 2 == 0:
@@ -19,6 +36,26 @@ func _ready() -> void:
 		# Pequeña pausa entre combates
 		await get_tree().create_timer(0.5).timeout
 	#get_tree().quit()
+
+
+## Al ejecutar TestBattle.tscn directamente no existe Main/DisplayManager; lo creamos aquí.
+func _ensure_display_manager() -> bool:
+	if DisplayManager.instance != null:
+		return true
+	_bootstrapped_display_manager = _DISPLAY_MANAGER_SCENE.instantiate() as DisplayManager
+	if _bootstrapped_display_manager == null:
+		push_error("TestBattle: no se pudo instanciar DisplayManager.tscn")
+		return false
+	# No se puede add_child() durante _ready() del árbol; diferir y esperar su _ready().
+	get_tree().root.add_child.call_deferred(_bootstrapped_display_manager)
+	if not _bootstrapped_display_manager.is_node_ready():
+		await _bootstrapped_display_manager.ready
+	if DisplayManager.instance == null:
+		push_error("TestBattle: DisplayManager no registró singleton tras _ready")
+		return false
+	print("TestBattle: DisplayManager de prueba inicializado (escena ejecutada en solitario).")
+	return true
+
 
 func wildSingleBattle():
 	# Usar equipo del jugador (configurado en Player Battler)
@@ -71,8 +108,8 @@ func wildDoubleBattle():
 
 func wildRandomSingleBattle():
 	# Generar equipos completamente aleatorios para jugador y salvaje
-	var playerParticipant: BattleParticipant = _create_random_player_participant(1)
-	var wildParticipant: BattleParticipant = _create_random_wild_participant(1)
+	var playerParticipant: BattleParticipant = _create_random_player_participant(test_player_party_size)
+	var wildParticipant: BattleParticipant = _create_random_wild_participant(WILD_PARTY_SINGLE)
 
 	var rules = BattleRules.new(
 		BattleRules.BattleTypes.WILD,
@@ -85,9 +122,9 @@ func wildRandomSingleBattle():
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
 func wildRandomDoubleBattle():
-	# Generar equipos completamente aleatorios para jugador (2) y salvajes (2)
-	var playerParticipant: BattleParticipant = _create_random_player_participant(2)
-	var wildParticipant: BattleParticipant = _create_random_wild_participant(2)
+	# Generar equipos aleatorios: en doble salen 2 activos; el party completo permite cambios.
+	var playerParticipant: BattleParticipant = _create_random_player_participant(test_player_party_size)
+	var wildParticipant: BattleParticipant = _create_random_wild_participant(WILD_PARTY_DOUBLE)
 
 	var rules = BattleRules.new(
 		BattleRules.BattleTypes.WILD,
@@ -114,20 +151,49 @@ func singleTrainerBattle():
 	var winner = await DisplayManager.start_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
-# Helper: genera un Pokémon aleatorio
-func _create_random_pokemon(is_wild: bool = false) -> BattlePokemon:
+## Rellena los Battler de escena para pruebas con party configurado en inspector.
+func _setup_test_battler_parties() -> void:
+	_fill_battler_random_party(player, test_player_party_size, false)
+	# Salvajes: máx. 2 (single usa el primero; doble los dos). Sin banca rival.
+	_trim_battler_party(wildPokemons, WILD_PARTY_DOUBLE)
+	_fill_battler_random_party(wildPokemons, WILD_PARTY_DOUBLE, true)
+	if singleTrainer != null and singleTrainer.party.is_empty():
+		_fill_battler_random_party(singleTrainer, test_trainer_party_size, false)
+
+
+func _fill_battler_random_party(battler: Battler, target_size: int, as_wild: bool) -> void:
+	if battler == null or target_size <= 0:
+		return
+	while battler.party.size() < target_size:
+		battler.add_pokemon_to_party(_create_random_pokemon_instance(as_wild))
+
+
+func _trim_battler_party(battler: Battler, max_size: int) -> void:
+	if battler == null or max_size < 0:
+		return
+	while battler.party.size() > max_size:
+		battler.party.pop_back()
+
+
+# Helper: genera un Pokémon aleatorio (instancia persistente / party)
+func _create_random_pokemon_instance(is_wild: bool = false) -> Pokemon:
 	var random_id = randi_range(1, 151)
 	var pokemon_data = DatabaseService.get_pokemon(random_id)
 	var pkmn := Pokemon.new(
-		pokemon_data,         # pokemon_data
-		randi_range(1, 100),  # pokemon_level
-		0,                    # pokemon_gender (0 = aleatorio)
-		0,                    # pokemon_ability (0 = aleatorio)
-		0,                    # pokemon_nature (0 = aleatorio)
-		true                  # randomize_stats
+		pokemon_data,
+		randi_range(1, 100),
+		0,
+		0,
+		0,
+		true
 	)
 	pkmn.is_wild = is_wild
-	return pkmn.to_battle_pokemon()
+	return pkmn
+
+
+# Helper: genera un BattlePokemon aleatorio
+func _create_random_pokemon(is_wild: bool = false) -> BattlePokemon:
+	return _create_random_pokemon_instance(is_wild).to_battle_pokemon()
 
 # Helper: genera participante salvaje con N Pokémon aleatorios
 func _create_random_wild_participant(num_pokemon: int = 1) -> BattleParticipant:

--- a/Scripts/Battle/core/Battle Choices/BattleBagChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleBagChoice.gd
@@ -12,10 +12,13 @@ var target_party_slot: int = -1
 
 ## Objetivo enemigo en runtime (p. ej. Poké Ball); opcional.
 var enemy_target_battle_pokemon: BattlePokemon = null
+var enemy_target_spot: BattleSpot = null
 
 
 ## Pokémon al que aplica el efecto en combate (aliado u oponente según el ítem).
 func resolve_item_target_battle_pokemon() -> BattlePokemon:
+	if enemy_target_spot != null:
+		return enemy_target_spot.get_active_pokemon()
 	if enemy_target_battle_pokemon != null:
 		return enemy_target_battle_pokemon
 	if battle_controller == null:

--- a/Scripts/Battle/core/Battle Choices/BattleChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleChoice.gd
@@ -2,12 +2,13 @@ class_name BattleChoice
 extends RefCounted
 
 var battle_spot: BattleSpot = null
-var pokemon: BattlePokemon:
-	get:
-		return battle_spot.get_active_pokemon() if battle_spot != null else null
-	set(value):
-		battle_spot = value.battle_spot if value != null else null
+## Pokémon que declaró la acción (fijado al elegir; no revalidar desde el spot tras un KO).
+var pokemon: BattlePokemon = null:
+	set(pkmn):
+		pokemon = pkmn
+		battle_spot = pkmn.battle_spot if pkmn != null else null
 var canceled: bool = false
+
 
 func get_priority() -> int:
 	return 0 # Por defecto, prioridad base

--- a/Scripts/Battle/core/Battle Choices/BattleChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleChoice.gd
@@ -1,7 +1,12 @@
 class_name BattleChoice
 extends RefCounted
 
-var pokemon: BattlePokemon = null
+var battle_spot: BattleSpot = null
+var pokemon: BattlePokemon:
+	get:
+		return battle_spot.get_active_pokemon() if battle_spot != null else null
+	set(value):
+		battle_spot = value.battle_spot if value != null else null
 var canceled: bool = false
 
 func get_priority() -> int:

--- a/Scripts/Battle/core/Battle Choices/BattleMoveChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleMoveChoice.gd
@@ -48,10 +48,10 @@ func resolve() -> Array[BattleHandler]:
 # Retorna el target válido si existe; en caso contrario devuelve null
 func _get_valid_single_enemy_target_or_null(original_target: BattleTarget) -> BattleTarget:
 	var tp := original_target.get_pokemon()
-	if tp != null and not tp.is_fainted() and tp.battle_spot != null:
+	if tp != null and tp.in_battle and not tp.is_fainted() and tp.battle_spot != null:
 		return original_target
 	var candidates := pokemon.get_opponent_side().get_active_pokemons()
 	candidates = candidates.filter(func(p): return p != tp and not p.is_fainted() and p.battle_spot != null)
 	if candidates.is_empty():
 		return null
-	return BattleTarget.new(candidates[0], original_target.selection_type)
+	return BattleTarget.new(candidates[0].battle_spot, original_target.selection_type)

--- a/Scripts/Battle/core/Battle Choices/BattleSwitchChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleSwitchChoice.gd
@@ -2,22 +2,36 @@ class_name BattleSwitchChoice
 extends BattleChoice
 
 var target_index: int # El índice del Pokémon al que cambiar
+var side: BattleSide = null
+var outgoing_pokemon: BattlePokemon = null
+var incoming_pokemon: BattlePokemon = null
+var origin_spot_index: int = -1
 
 func get_priority() -> int:
 	return 6 # En los juegos oficiales, cambiar tiene prioridad 6
 
 func resolve() -> Array[BattleHandler]:
 	# Crear el handler de switch
+	var side_ref := side if side != null else pokemon.side
+	if side_ref == null:
+		print("[SWITCH] Side inválido")
+		return []
 	var spot := pokemon.battle_spot
-	var current := spot.get_active_pokemon()
+	if spot == null:
+		print("[SWITCH] Spot de origen inválido")
+		return []
+	var current := outgoing_pokemon if outgoing_pokemon != null else spot.get_active_pokemon()
 	var target_idx := target_index
-	var party := pokemon.side.pokemonParty
-	
+	var party := side_ref.pokemonParty
+
 	if target_idx < 0 or target_idx >= party.size():
 		print("[SWITCH] Índice destino inválido")
 		return []
-	
-	var incoming: BattlePokemon = party[target_idx]
+
+	var incoming: BattlePokemon = incoming_pokemon if incoming_pokemon != null else party[target_idx]
+	if incoming == null:
+		print("[SWITCH] Pokémon de entrada inválido")
+		return []
 	if incoming == current:
 		print("[SWITCH] Mismo Pokémon, no se realiza el cambio")
 		return []
@@ -25,6 +39,6 @@ func resolve() -> Array[BattleHandler]:
 	if incoming.in_battle:
 		print("[SWITCH] El Pokémon ya está en combate")
 		return []
-	
-	var handler = BattleSwitchHandler.new(pokemon.side, spot, current, incoming, pokemon.side.battle_rules)
+
+	var handler = BattleSwitchHandler.new(side_ref, spot, current, incoming, side_ref.battle_rules)
 	return [handler]

--- a/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
@@ -16,6 +16,10 @@ func _init(_side: BattleSide, _spot: BattleSpot, _out: BattlePokemon, _in: Battl
 
 func apply():
     if out_pokemon:
+        # Al salir del campo, sus efectos persistentes de combate dejan de estar activos.
+        var effects_ctrl := BattleEffectController.get_instance()
+        if effects_ctrl != null:
+            effects_ctrl._clear_pokemon_effects(out_pokemon)
         out_pokemon.in_battle = false
     if spot and in_pokemon:
         spot.load_active_pokemon(in_pokemon, rules)
@@ -24,9 +28,9 @@ func visualize(ui):
     # Muestra mensaje y animación de switch
     var out_name = out_pokemon.get_name() if out_pokemon else "(ninguno)"
     var in_name = in_pokemon.get_name() if in_pokemon else "(ninguno)"
-    
+
     await ui.show_switch_message(side.to_string(), in_name)
-    
+
     # Log de debug (opcional)
     print("[SWITCH] Sale %s, entra %s" % [out_name, in_name])
 

--- a/Scripts/Battle/core/Battle Effects/Persistent/Ailments/BurnAilmentEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Ailments/BurnAilmentEffect.gd
@@ -3,7 +3,7 @@ extends PersistentBattleEffect
 
 
 func apply_phase(pokemon:BattlePokemon, phase: Phases) -> void: 
-	if phase != BattleEffect.Phases.ON_END_POKEMON_TURN:
+	if phase != BattleEffect.Phases.ON_END_BATTLE_TURN:
 		return
 		
 	var dmg:int = ceil(pokemon.total_hp / 16.0)
@@ -15,7 +15,7 @@ func apply_phase(pokemon:BattlePokemon, phase: Phases) -> void:
 	pokemon.take_damage(burn_effect)
 
 func visualize_phase(pokemon:BattlePokemon, ui: BattleUI, phase: Phases) -> void:
-	if phase != BattleEffect.Phases.ON_END_POKEMON_TURN:
+	if phase != BattleEffect.Phases.ON_END_BATTLE_TURN:
 		return
 
 	await ui.show_effect_message(MessageFamily.Values.AILMENT, pokemon, source.id)

--- a/Scripts/Battle/core/Battle Effects/Persistent/Ailments/PoisonAilmentEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Ailments/PoisonAilmentEffect.gd
@@ -3,7 +3,7 @@ extends PersistentBattleEffect
 
 
 func apply_phase(pokemon, phase: Phases) -> void: 
-	if phase != BattleEffect.Phases.ON_END_POKEMON_TURN:
+	if phase != BattleEffect.Phases.ON_END_BATTLE_TURN:
 		return
 	var dmg:int = ceil(pokemon.total_hp / 8.0)
 	var effect := DamageEffect.new(null, pokemon, null, dmg)
@@ -11,7 +11,7 @@ func apply_phase(pokemon, phase: Phases) -> void:
 
 
 func visualize_phase(pokemon: BattlePokemon, ui: BattleUI, phase: BattleEffect.Phases):
-	if phase != BattleEffect.Phases.ON_END_POKEMON_TURN:
+	if phase != BattleEffect.Phases.ON_END_BATTLE_TURN:
 		return
 
 	await ui.show_effect_message(MessageFamily.Values.AILMENT, pokemon, source.id)

--- a/Scripts/Battle/core/BattleTarget.gd
+++ b/Scripts/Battle/core/BattleTarget.gd
@@ -7,6 +7,7 @@ extends RefCounted
 ## Scope: Tipo de objetivo (Pokémon individual, Side o Field completo)
 enum Scope {
 	POKEMON,  # Target es un BattlePokemon
+	SPOT,     # Target es un BattleSpot (resuelve al activo dinámicamente)
 	SIDE,     # Target es un BattleSide
 	FIELD     # Target es el campo completo (sin objeto específico)
 }
@@ -29,6 +30,9 @@ func _init(target = null, _selection_type: TYPE = TYPE.NONE):
 	if target is BattlePokemon:
 		scope = Scope.POKEMON
 		_target_object = target
+	elif target is BattleSpot:
+		scope = Scope.SPOT
+		_target_object = target
 	elif target is BattleSide:
 		scope = Scope.SIDE
 		_target_object = target
@@ -49,6 +53,12 @@ func get_name() -> String:
 			if _target_object:
 				return _target_object.get_name()
 			return "Unknown Pokémon"
+		Scope.SPOT:
+			var sp: BattleSpot = _target_object as BattleSpot
+			if sp == null:
+				return "Unknown Spot"
+			var active := sp.get_active_pokemon()
+			return active.get_name() if active != null else "Empty Spot"
 		Scope.SIDE:
 			if _target_object:
 				return _target_object.to_string()
@@ -60,7 +70,11 @@ func get_name() -> String:
 
 ## Verifica si este target es de tipo Pokémon
 func is_pokemon() -> bool:
-	return scope == Scope.POKEMON
+	return scope == Scope.POKEMON or scope == Scope.SPOT
+
+## Verifica si este target es de tipo Spot
+func is_spot() -> bool:
+	return scope == Scope.SPOT
 
 ## Verifica si este target es de tipo Side
 func is_side() -> bool:
@@ -78,7 +92,18 @@ func is_single_enemy_selection_type() -> bool:
 func get_pokemon() -> BattlePokemon:
 	if scope == Scope.POKEMON:
 		return _target_object as BattlePokemon
+	if scope == Scope.SPOT:
+		var spot: BattleSpot = _target_object as BattleSpot
+		if spot != null:
+			return spot.get_active_pokemon()
 	return null
+
+## Obtiene el Spot si el scope es SPOT, sino null
+func get_spot() -> BattleSpot:
+	if scope == Scope.SPOT:
+		return _target_object as BattleSpot
+	var p := get_pokemon()
+	return p.battle_spot if p != null else null
 
 ## Obtiene el Side si el scope es SIDE, sino null
 func get_side() -> BattleSide:
@@ -87,7 +112,8 @@ func get_side() -> BattleSide:
 	return null
 
 func is_valid_pokemon() -> bool:
-	return get_pokemon() and !get_pokemon().is_fainted()
+	var p := get_pokemon()
+	return p != null and p.in_battle and not p.is_fainted()
 
 func is_valid_side() -> bool:
 	return get_side() != null

--- a/Scripts/Battle/core/BattleTargetSelector.gd
+++ b/Scripts/Battle/core/BattleTargetSelector.gd
@@ -15,17 +15,20 @@ func resolve_targets(move: BattleMove, user: BattlePokemon, manual_target: Battl
 			
 		BattleTarget.TYPE.YO_PRIMERO, BattleTarget.TYPE.USER:
 			# El usuario se apunta a sí mismo
-			targets.append(BattleTarget.new(user, target_type))
+			if user.battle_spot != null:
+				targets.append(BattleTarget.new(user.battle_spot, target_type))
 			
 		BattleTarget.TYPE.ALIADO:
-			var ally := _get_ally_pokemon(user)
-			if ally:
-				targets.append(BattleTarget.new(ally, target_type))
+			var ally_spot := _get_ally_spot(user)
+			if ally_spot:
+				targets.append(BattleTarget.new(ally_spot, target_type))
 				
 		BattleTarget.TYPE.USER_OR_ALLY:
-			var ally := _get_ally_pokemon(user)
-			var target_pokemon = ally if ally else user
-			targets.append(BattleTarget.new(target_pokemon, target_type))
+			var target_spot: BattleSpot = _get_ally_spot(user)
+			if target_spot == null:
+				target_spot = user.battle_spot
+			if target_spot != null:
+				targets.append(BattleTarget.new(target_spot, target_type))
 			
 		BattleTarget.TYPE.BASE_PLAYER:
 			# Target es el lado del jugador
@@ -36,42 +39,42 @@ func resolve_targets(move: BattleMove, user: BattlePokemon, manual_target: Battl
 			targets.append(BattleTarget.new(user.get_opponent_side(), target_type))
 			
 		BattleTarget.TYPE.RANDOM_ENEMY:
-			var random_enemy := _get_random_enemy_pokemon(user)
-			if random_enemy:
-				targets.append(BattleTarget.new(random_enemy, target_type))
+			var random_enemy_spot := _get_random_enemy_spot(user)
+			if random_enemy_spot:
+				targets.append(BattleTarget.new(random_enemy_spot, target_type))
 				
 		BattleTarget.TYPE.SELECCIONAR:
 			# Si hay un target manual, usarlo; sino seleccionar enemigo aleatorio
 			if manual_target and manual_target.has_active_pokemon():
-				targets.append(BattleTarget.new(manual_target.get_active_pokemon(), target_type))
+				targets.append(BattleTarget.new(manual_target, target_type))
 			else:
-				var random_enemy2 := _get_random_enemy_pokemon(user)
+				var random_enemy2 := _get_random_enemy_spot(user)
 				if random_enemy2:
 					targets.append(BattleTarget.new(random_enemy2, target_type))
 					
 		BattleTarget.TYPE.ENEMIES:
 			# Todos los enemigos activos como targets individuales
-			var enemies := _get_enemy_pokemons(user)
-			for enemy in enemies:
-				targets.append(BattleTarget.new(enemy, target_type))
+			var enemy_spots := _get_enemy_spots(user)
+			for spot in enemy_spots:
+				targets.append(BattleTarget.new(spot, target_type))
 				
 		BattleTarget.TYPE.PLAYERS:
 			# Todos los aliados activos como targets individuales
-			var allies := _get_ally_side_pokemons(user)
-			for ally in allies:
-				targets.append(BattleTarget.new(ally, target_type))
+			var ally_spots := _get_ally_spots(user)
+			for ally_spot in ally_spots:
+				targets.append(BattleTarget.new(ally_spot, target_type))
 				
 		BattleTarget.TYPE.ALL_OTHER:
 			# Todos los pokémon excepto el usuario
-			var all_others := _get_all_other_pokemons(user)
-			for pokemon in all_others:
-				targets.append(BattleTarget.new(pokemon, target_type))
+			var other_spots := _get_all_other_spots(user)
+			for other_spot in other_spots:
+				targets.append(BattleTarget.new(other_spot, target_type))
 				
 		BattleTarget.TYPE.ALL_POKEMON:
 			# Todos los pokémon en el campo
-			var all_pokemon := _get_all_active_pokemons(user)
-			for pokemon in all_pokemon:
-				targets.append(BattleTarget.new(pokemon, target_type))
+			var all_spots := _get_all_active_spots(user)
+			for active_spot in all_spots:
+				targets.append(BattleTarget.new(active_spot, target_type))
 				
 		BattleTarget.TYPE.ALL_FIELD:
 			# El campo completo - un único target de tipo FIELD
@@ -118,6 +121,16 @@ func _get_all_other_pokemons(user: BattlePokemon) -> Array[BattlePokemon]:
 	var all := _get_all_active_pokemons(user)
 	return all.filter(func(p): return p != user)
 
+func _get_all_active_spots(user: BattlePokemon) -> Array[BattleSpot]:
+	var spots: Array[BattleSpot] = []
+	spots.append_array(_get_ally_spots(user))
+	spots.append_array(_get_enemy_spots(user))
+	return spots
+
+func _get_all_other_spots(user: BattlePokemon) -> Array[BattleSpot]:
+	var all_spots := _get_all_active_spots(user)
+	return all_spots.filter(func(s): return s != user.battle_spot)
+
 func _get_enemy_spots(user: BattlePokemon) -> Array[BattleSpot]:
 	return user.get_opponent_side().battle_spots.filter(
 		func(s): return s.has_active_pokemon()
@@ -133,6 +146,18 @@ func _get_random_enemy_pokemon(user: BattlePokemon) -> BattlePokemon:
 	if enemies.is_empty():
 		return null
 	return enemies[randi() % enemies.size()]
+
+func _get_random_enemy_spot(user: BattlePokemon) -> BattleSpot:
+	var enemy_spots := _get_enemy_spots(user)
+	if enemy_spots.is_empty():
+		return null
+	return enemy_spots[randi() % enemy_spots.size()]
+
+func _get_ally_spot(user: BattlePokemon) -> BattleSpot:
+	for spot in _get_ally_spots(user):
+		if spot != user.battle_spot:
+			return spot
+	return null
 
 func _get_ally_pokemon(user: BattlePokemon) -> BattlePokemon:
 	# Devuelve el compañero del usuario si existe

--- a/Scripts/Battle/core/Controllers/BattleController.gd
+++ b/Scripts/Battle/core/Controllers/BattleController.gd
@@ -297,7 +297,9 @@ func grant_experience_after_enemy_ko(defeated_enemy: BattlePokemon, action_execu
 			lv_before = lvl_res.old_level
 			lv_gained = lvl_res.levels_gained
 		var spot: BattleSpot = bp.battle_spot
-		if spot != null and spot.hp_bar != null:
+		var should_animate_exp_bar: bool = spot != null and spot.hp_bar != null and bp.in_battle \
+			and spot.get_active_pokemon() == bp
+		if should_animate_exp_bar:
 			var old_total: int = po.new_total_exp - po.gained_exp
 			# Durante la animación EXP, el nivel en pantalla debe seguir siendo el de antes hasta llenar el trozo actual.
 			if lv_gained > 0:

--- a/Scripts/Battle/core/Controllers/BattleEffectController.gd
+++ b/Scripts/Battle/core/Controllers/BattleEffectController.gd
@@ -19,6 +19,9 @@ static func add_pokemon_effect(pokemon, effect: PersistentBattleEffect):
 static func remove_pokemon_effect(pokemon, effect: PersistentBattleEffect):
 	get_instance()._remove_pokemon_effect(pokemon, effect)
 
+static func clear_pokemon_effects(pokemon):
+	get_instance()._clear_pokemon_effects(pokemon)
+
 static func add_side_effect(side: String, effect: PersistentBattleEffect):
 	get_instance()._add_side_effect(side, effect)
 
@@ -30,7 +33,7 @@ static func add_field_effect(effect: PersistentBattleEffect):
 
 static func remove_field_effect(effect: PersistentBattleEffect):
 	get_instance()._remove_field_effect(effect)
-	
+
 static func has_effect_for(pokemon, effect_instance: PersistentBattleEffect) -> bool:
 	return effect_instance != null and get_instance()._has_effect_for(pokemon, effect_instance)
 
@@ -110,6 +113,12 @@ func _remove_pokemon_effect(pokemon, effect: PersistentBattleEffect):
 	if pokemon_effects[pokemon].is_empty():
 		pokemon_effects.erase(pokemon)
 
+func _clear_pokemon_effects(pokemon) -> void:
+	if pokemon == null:
+		return
+	if pokemon_effects.has(pokemon):
+		pokemon_effects.erase(pokemon)
+
 func _add_side_effect(side: String, effect: PersistentBattleEffect):
 	if not side_effects.has(side):
 		side_effects[side] = []
@@ -129,7 +138,7 @@ func _add_field_effect(effect: PersistentBattleEffect):
 func _remove_field_effect(effect: PersistentBattleEffect):
 	var target_class = effect.get_script().get_global_name()
 	field_effects = field_effects.filter(func(e): return e.get_script().get_global_name() != target_class)
-	
+
 func _has_effect_for(pokemon, effect: PersistentBattleEffect) -> bool:
 	var target_class = effect.get_script().get_global_name()
 	var all = _get_all_effects_for(pokemon)
@@ -179,7 +188,7 @@ func _get_all_active_effects() -> Array[PersistentBattleEffect]:
 func _process_phase(pokemon: BattlePokemon, phase: BattleEffect.Phases):
 	apply_phase(pokemon, phase)
 	await visualize_phase(pokemon, phase)
-	
+
 func _process_global_phase(phase: BattleEffect.Phases):
 	for effect in field_effects:
 		effect.apply_phase(null, phase)
@@ -192,7 +201,18 @@ func _process_global_phase(phase: BattleEffect.Phases):
 		for effect in side_effects[side]:
 			await effect.visualize_phase(null, ui, phase)
 			if effect.has_finished(): remove_side_effect(side, effect)
-			
+	# Efectos persistentes ligados a Pokémon (veneno/quemadura/etc.) en fase global de fin de turno.
+	for bp in pokemon_effects.keys():
+		var pokemon: BattlePokemon = bp as BattlePokemon
+		if pokemon == null:
+			continue
+		for effect in _get_pokemon_effects(pokemon):
+			effect.apply_phase(pokemon, phase)
+		for effect in _get_pokemon_effects(pokemon):
+			await effect.visualize_phase(pokemon, ui, phase)
+			if effect.has_finished():
+				remove_pokemon_effect(pokemon, effect)
+
 func _apply_phase(pokemon, phase):
 	for effect in _get_all_effects_for(pokemon):
 		effect.apply_phase(pokemon, phase)
@@ -201,7 +221,7 @@ func _visualize_phase(pokemon, phase):
 	for effect in _get_all_effects_for(pokemon):
 		await effect.visualize_phase(pokemon, ui, phase)
 		if effect.has_finished(): remove_pokemon_effect(pokemon, effect)
-			
+
 
 func _apply_global_phase(phase: BattleEffect.Phases) -> void:
 	for effect in field_effects:

--- a/Scripts/Battle/core/Controllers/BattleTurnController.gd
+++ b/Scripts/Battle/core/Controllers/BattleTurnController.gd
@@ -166,8 +166,6 @@ func handle_result(choice: BattleChoice, handlers: Array[BattleHandler]) -> void
 	else:
 		push_warning("handle_result: tipo de choice no reconocido o aún no implementado.")
 
-	await BattleEffectController.process_phase(choice.pokemon, BattleEffect.Phases.ON_END_POKEMON_TURN)
-
 #
 func handle_move_result(choice: BattleMoveChoice, handlers: Array[BattleHandler]) -> void:
 

--- a/Scripts/Battle/core/Controllers/BattleTurnController.gd
+++ b/Scripts/Battle/core/Controllers/BattleTurnController.gd
@@ -84,7 +84,7 @@ func execute_turn():
 
 	#Calculamos y resolvemos las acciones seleccionadas por cada pokémon activo
 	for choice:BattleChoice in ordered_choices:
-		if choice.pokemon.is_fainted():
+		if _should_skip_choice(choice):
 			continue
 		results[choice] = choice.resolve()
 
@@ -93,14 +93,13 @@ func execute_turn():
 	# Mostrar animaciones y efectos tras resolver todo
 	for choice in ordered_choices:
 		if results.has(choice):
-			# Verificar si el Pokémon sigue vivo antes de ejecutar su acción
-			# Esto previene que un Pokémon debilitado ejecute su movimiento
-			if not choice.pokemon.is_fainted():
+			var actor: BattlePokemon = choice.pokemon
+			# El rival puede haber caído antes de su turno (más rápido que él): no ejecutar ni revisar KO con actor nulo.
+			if actor != null and not actor.is_fainted():
 				await handle_result(choice, results[choice])
 
-			# Verificar y mostrar mensajes de debilitamiento después de cada acción
-			# Pasamos el pokemon que ejecutó la acción para mostrar primero los del rival
-			await check_and_show_fainted_pokemon(choice.pokemon)
+			if actor != null:
+				await check_and_show_fainted_pokemon(actor)
 
 			# Verificar si el combate ha terminado después de cada acción
 			if battle_controller.battle_finished():
@@ -114,8 +113,11 @@ func order_choices(battle_choices: Array[BattleChoice]) -> Array[BattleChoice]:
 	battle_choices.sort_custom(_sort_choices)
 	print(">>> Orden de ejecución:")
 	for choice:BattleChoice in battle_choices:
-		var pkmn_name = choice.pokemon.get_name()
-		var speed = choice.pokemon.get_speed()
+		var actor: BattlePokemon = choice.pokemon
+		if actor == null:
+			continue
+		var pkmn_name = actor.get_name()
+		var speed = actor.get_speed()
 		var action_desc := ""
 		if choice is BattleMoveChoice and choice.get_move() != null:
 			action_desc = "usará %s" % choice.get_move().get_name()
@@ -134,14 +136,19 @@ func order_choices(battle_choices: Array[BattleChoice]) -> Array[BattleChoice]:
 
 
 
+func _should_skip_choice(choice: BattleChoice) -> bool:
+	var actor: BattlePokemon = choice.pokemon
+	return actor == null or actor.is_fainted()
+
+
 func _sort_choices(a: BattleChoice, b: BattleChoice) -> bool:
 	# 1. Prioridad
 	if a.get_priority() != b.get_priority():
 		return a.get_priority() > b.get_priority()
 
 	# 2. Velocidad
-	var speed_a = a.pokemon.get_speed()
-	var speed_b = b.pokemon.get_speed()
+	var speed_a: int = a.pokemon.get_speed() if a.pokemon != null else 0
+	var speed_b: int = b.pokemon.get_speed() if b.pokemon != null else 0
 
 	if speed_a != speed_b:
 		return speed_a > speed_b

--- a/Scripts/Battle/core/Handlers/BattleMoveHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattleMoveHandler.gd
@@ -52,12 +52,12 @@ func ensure_valid_single_enemy_target_or_null() -> bool:
 		return true
 
 	var tp: BattlePokemon = target.get_pokemon()
-	if tp != null and not tp.is_fainted() and tp.battle_spot != null:
+	if tp != null and tp.in_battle and not tp.is_fainted() and tp.battle_spot != null:
 		return true
 	
 	var candidates: Array[BattlePokemon] = user.get_opponent_side().get_active_pokemons()
 	candidates = candidates.filter(func(p): return p != tp and not p.is_fainted() and p.battle_spot != null)
 	if candidates.is_empty():
 		return false
-	target = BattleTarget.new(candidates[0], target.selection_type)
+	target = BattleTarget.new(candidates[0].battle_spot, target.selection_type)
 	return true

--- a/Scripts/Battle/ui/BattlePartySwitchController.gd
+++ b/Scripts/Battle/ui/BattlePartySwitchController.gd
@@ -1,0 +1,112 @@
+extends RefCounted
+class_name BattlePartySwitchController
+
+const SLOT_COUNT: int = 6
+
+var _side: BattleSide
+var _active_pokemon: BattlePokemon
+var _force_switch: bool = false
+
+
+func _init(side: BattleSide, active_pokemon: BattlePokemon, force_switch: bool = false) -> void:
+	_side = side
+	_active_pokemon = active_pokemon
+	_force_switch = force_switch
+
+
+func get_slot_count() -> int:
+	return SLOT_COUNT
+
+
+func get_party_members_ordered() -> Array[Pokemon]:
+	var out: Array[Pokemon] = []
+	if _side == null:
+		return out
+	for bp in _side.pokemonParty:
+		if bp != null and bp.base_data != null:
+			out.append(bp.base_data)
+	return out
+
+
+func touch_pokemon(_mon: Pokemon) -> void:
+	# No-op: en combate la fuente de verdad es BattlePokemon/base_data ya inicializado.
+	pass
+
+
+func get_slot_view(slot: int) -> Dictionary:
+	var bp: BattlePokemon = get_battle_pokemon_at(slot)
+	if bp == null or bp.base_data == null:
+		return {"occupied": false}
+
+	var mon: Pokemon = bp.base_data
+	var max_hp := mon.get_final_stat(StatsEnum.Values.HP)
+	var status := "—"
+	if bp.is_fainted():
+		status = "Debilitado"
+	elif mon.major_status != CONST.STATUS.OK:
+		status = AilmentData.major_status_display_name(mon.major_status)
+
+	return {
+		"occupied": true,
+		"display_name": mon.get_display_name(),
+		"species_name": mon.base.Name,
+		"level": mon.level,
+		"hp_current": bp.get_hp(),
+		"hp_max": max_hp,
+		"status_text": status,
+		"icon": mon.get_icon_sprite(),
+		"gender": mon.gender,
+		"pokemon": mon,
+		"battle_pokemon": bp,
+		"is_active": bp == _active_pokemon
+	}
+
+
+func is_slot_occupied(slot: int) -> bool:
+	return bool(get_slot_view(slot).get("occupied", false))
+
+
+func get_battle_pokemon_at(slot: int) -> BattlePokemon:
+	if _side == null:
+		return null
+	if slot < 0 or slot >= SLOT_COUNT:
+		return null
+	if slot >= _side.pokemonParty.size():
+		return null
+	return _side.pokemonParty[slot]
+
+
+func find_slot_for_battle_pokemon(target: BattlePokemon) -> int:
+	if _side == null or target == null:
+		return -1
+	for i in range(_side.pokemonParty.size()):
+		if _side.pokemonParty[i] == target:
+			return i
+	return -1
+
+
+func is_selectable_switch_slot(slot: int) -> bool:
+	return get_invalid_switch_reason(slot).is_empty()
+
+
+func get_invalid_switch_reason(slot: int) -> String:
+	if not is_slot_occupied(slot):
+		return "No hay ningún Pokémon en ese slot."
+
+	var candidate: BattlePokemon = get_battle_pokemon_at(slot)
+	if candidate == null:
+		return "No hay ningún Pokémon en ese slot."
+	if candidate == _active_pokemon:
+		return "%s ya está en el campo de batalla." % candidate.get_display_name()
+	if candidate.is_fainted():
+		return "¡A %s no le quedan fuerzas para luchar!" % candidate.get_display_name()
+	if candidate.in_battle:
+		return "%s ya está en el campo de batalla." % candidate.get_display_name()
+	if not candidate.inBattleParty:
+		return "%s no está disponible para este combate." % candidate.get_display_name()
+	return ""
+
+
+func can_cancel_battle_switch() -> bool:
+	return not _force_switch
+

--- a/Scripts/Battle/ui/BattlePartySwitchController.gd.uid
+++ b/Scripts/Battle/ui/BattlePartySwitchController.gd.uid
@@ -1,0 +1,1 @@
+uid://bd0sutx3r7q8g

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -9,11 +9,13 @@ const _BAG_SCENE := preload("res://Scenes/UI/BAG.tscn")
 const _BAG_CONTROLLER_SCRIPT := preload("res://Scripts/UI/BagController.gd")
 const _PARTY_SCENE := preload("res://Scenes/UI/2 - Party/PARTY.tscn")
 const _PARTY_CONTROLLER_SCRIPT := preload("res://Scripts/UI/PartyController.gd")
+const _BATTLE_PARTY_SWITCH_CONTROLLER := preload("res://Scripts/Battle/ui/BattlePartySwitchController.gd")
 
 @onready var message_controller:BattleMessageController = $MessageController
 @onready var field_ui:FieldUI = $FieldUI
 #@onready var party_ui = $PartyUI
 @onready var actions_menu = $ActionsMenu
+@onready var party_ui: PartyUI = $PartyUI
 @onready var message_box:MessageBox = $MessageBox
 @onready var moves_menu = $MovesMenu
 @onready var target_selector_ui = $TargetSelectorUI
@@ -35,6 +37,9 @@ const FAMILY := MessageFamily.Values
 func _ready() -> void:
 	result_display.ui = self
 	visible = false
+	if party_ui != null:
+		# Party en combate debe superponerse al campo (sprites/HPBars).
+		party_ui.z_index = 40
 	_move_learning_flow = _MOVE_LEARNING_FLOW.new()
 	_level_up_stats_panel = _LEVELUP_STATS_SCENE.instantiate() as Panel
 	add_child(_level_up_stats_panel)
@@ -108,6 +113,11 @@ func show_action_selection(pokemon: BattlePokemon) -> BattleChoice:
 			(choice as BattleBagChoice).battle_controller = battle_controller
 		return await show_bag_item_selection(pokemon)
 
+	# Cambio de Pokémon requiere abrir Party UI y devolver un BattleSwitchChoice completo.
+	if choice is BattleSwitchChoice:
+		return await show_switch_selection(pokemon)
+
+	# Si no es LUCHAR, devolvemos directamente
 	if choice is not BattleMoveChoice:
 		return choice
 
@@ -215,6 +225,7 @@ func show_bag_item_selection(pokemon: BattlePokemon) -> BattleChoice:
 		out.item_id = picked_id
 		out.target_party_slot = -1
 		out.enemy_target_battle_pokemon = null
+		out.enemy_target_spot = null
 		if selected_item_data == null:
 			continue
 
@@ -239,12 +250,12 @@ func show_bag_item_selection(pokemon: BattlePokemon) -> BattleChoice:
 			continue
 		elif _battle_item_needs_enemy_target_pick(selected_item_data):
 			_battle_bag_ui.close()
-			var foe: BattlePokemon = await _pick_enemy_target_for_item(pokemon)
-			if foe == null:
+			var foe_spot: BattleSpot = await _pick_enemy_target_spot_for_item(pokemon)
+			if foe_spot == null:
 				if _battle_bag_ui != null and not _battle_bag_ui.visible:
 					_battle_bag_ui.open()
 				continue
-			out.enemy_target_battle_pokemon = foe
+			out.enemy_target_spot = foe_spot
 			return out
 		else:
 			_battle_bag_ui.close()
@@ -447,14 +458,67 @@ func _reset_bag_ui_after_party_cancel() -> void:
 		_battle_bag_ui.set_input_enabled(true)
 
 
-func _pick_enemy_target_for_item(actor: BattlePokemon) -> BattlePokemon:
+func _pick_enemy_target_spot_for_item(actor: BattlePokemon) -> BattleSpot:
 	var spot: BattleSpot = await show_target_selection(actor)
 	if spot == null:
 		return null
 	if not spot.has_active_pokemon():
 		return null
-	return spot.get_active_pokemon()
+	return spot
+func show_switch_selection(pokemon: BattlePokemon) -> BattleChoice:
+	if party_ui == null:
+		push_error("BattleUI: PartyUI no está disponible en la escena de batalla.")
+		var canceled := BattleChoice.new()
+		canceled.canceled = true
+		return canceled
 
+	var switch_controller = _BATTLE_PARTY_SWITCH_CONTROLLER.new(pokemon.side, pokemon, false)
+	party_ui.setup(switch_controller)
+	actions_menu.hide()
+	moves_menu.hide()
+	target_selector_ui.hide()
+	message_box.hide()
+
+	var current_slot: int = switch_controller.find_slot_for_battle_pokemon(pokemon)
+	party_ui.open_for_battle_switch_pick(current_slot, false)
+
+	var selection_state := {
+		"selected_slot": -1,
+		"canceled": false,
+		"done": false
+	}
+
+	var on_selected := func(slot_index: int) -> void:
+		selection_state["selected_slot"] = slot_index
+		selection_state["done"] = true
+	var on_canceled := func() -> void:
+		selection_state["canceled"] = true
+		selection_state["done"] = true
+
+	party_ui.battle_switch_slot_selected.connect(on_selected, CONNECT_ONE_SHOT)
+	party_ui.battle_switch_cancelled.connect(on_canceled, CONNECT_ONE_SHOT)
+	while not bool(selection_state["done"]):
+		await get_tree().process_frame
+
+	party_ui.close()
+
+	if bool(selection_state["canceled"]):
+		return await show_action_selection(pokemon)
+
+	var selected_slot: int = int(selection_state["selected_slot"])
+	var incoming_bp: BattlePokemon = switch_controller.get_battle_pokemon_at(selected_slot)
+	if incoming_bp == null:
+		return await show_action_selection(pokemon)
+
+	var choice := BattleSwitchChoice.new()
+	choice.pokemon = pokemon
+	choice.side = pokemon.side
+	choice.target_index = selected_slot
+	choice.outgoing_pokemon = pokemon
+	choice.incoming_pokemon = incoming_bp
+	if pokemon.battle_spot != null:
+		choice.origin_spot_index = pokemon.battle_spot.index
+	return choice
 
 func show_action_menu_for(pokemon: BattlePokemon) -> BattleChoice:
 	if pokemon.battle_spot.has_previous_controllable_pokemon():
@@ -482,19 +546,19 @@ func show_move_selection(pokemon: BattlePokemon) -> BattleMoveChoice:
 	# Verificar si necesita selección manual de target (usando la lógica, no la UI)
 	var move: BattleMove = move_choice.get_move()
 	var target_type := move.base_data.get_target_id() as BattleTarget.TYPE
-	
+
 	var selected_spot: BattleSpot = null
 	if target_selector != null and target_selector.requires_manual_selection(target_type, pokemon):
 		selected_spot = await show_target_selection(pokemon)
-		
+
 		if selected_spot == null:
 			# Usuario canceló la selección de target
 			return await show_move_selection(pokemon)
-	
+
 	# Generar los targets aquí usando la lógica y asignarlos al choice
 	if target_selector != null:
 		move_choice.targets = target_selector.resolve_targets(move, pokemon, selected_spot)
-	
+
 	moves_menu.hide()
 	return move_choice
 
@@ -509,15 +573,15 @@ func show_target_selection(user: BattlePokemon) -> BattleSpot:
 		return candidates[0]
 
 	target_selector_ui.show_targets(candidates)
-	
+
 	# Esperar a que se seleccione un target - await devuelve directamente el parámetro de la señal
 	var selected_spot: BattleSpot = await target_selector_ui.target_chosen
-	
+
 	return selected_spot
-	
+
 func hide_action_menu():
 	actions_menu.hide()
-	
+
 func play_intro_sequence(rules,player_pokemon,enemy_pokemon,player_trainers,enemy_trainers) -> void:
 	var intro_messages = message_controller.get_intro_messages(
 		rules,
@@ -530,13 +594,13 @@ func play_intro_sequence(rules,player_pokemon,enemy_pokemon,player_trainers,enem
 	for msg in intro_messages:
 		await show_message_from_dict(msg)
 		print("escrito!")
-	
+
 	# Aquí podrías activar el menú o iniciar la siguiente fase del combate
 	actions_menu.show()
-	
+
 func show_used_move_message(user: BattlePokemon, move: BattleMove) -> void:
 	await show_message_from_dict(message_controller.get_used_move_message(user, move))
-	
+
 func show_failed_move_message(user: BattlePokemon) -> void:
 	await show_message_from_dict(message_controller.get_failed_move_message(user))
 	clear_message_box()
@@ -559,7 +623,7 @@ func show_no_target_message(user: BattlePokemon) -> void:
 
 func show_heal_message(pokemon: BattlePokemon) -> void:
 	await show_message_from_dict(message_controller.get_heal_message(pokemon))
-	
+
 
 func show_drain_message(pokemon: BattlePokemon) -> void:
 	await show_message_from_dict(message_controller.get_drain_message(pokemon))
@@ -585,7 +649,7 @@ func show_switch_message(trainer_name: String, pokemon_name: String) -> void:
 func show_battle_end_message(winner_side: String, rules: BattleRules, enemy_participants: Array) -> void:
 	# Mostrar mensaje de victoria
 	await show_message_from_dict(message_controller.get_battle_end_message(winner_side, rules, enemy_participants))
-	
+
 	# Si el jugador ganó contra un entrenador, mostrar mensaje de derrota del trainer
 	if winner_side == "player" and rules.type == BattleRules.BattleTypes.TRAINER:
 		for participant in enemy_participants:
@@ -725,7 +789,9 @@ func has_modal_ui_visible() -> bool:
 		return true
 	if _battle_bag_ui != null and _battle_bag_ui.visible:
 		return true
-	return _battle_party_ui != null and _battle_party_ui.visible
+	if _battle_party_ui != null and _battle_party_ui.visible:
+		return true
+	return party_ui != null and party_ui.visible
 
 
 # API unificada por variante (source es SIEMPRE int id)

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -541,7 +541,7 @@ func show_move_selection(pokemon: BattlePokemon) -> BattleMoveChoice:
 		# Si el usuario cancela el menú de movimientos, se vuelve a mostrar el menú de acciones
 		return await show_action_selection(pokemon)
 
-	move_choice.pokemon = pokemon  # también aquí, por seguridad
+	move_choice.pokemon = pokemon
 
 	# Verificar si necesita selección manual de target (usando la lógica, no la UI)
 	var move: BattleMove = move_choice.get_move()
@@ -572,6 +572,10 @@ func show_target_selection(user: BattlePokemon) -> BattleSpot:
 	if candidates.size() == 1:
 		return candidates[0]
 
+	# El menú de movimientos puede conservar foco; sin modal visible DisplayManager no emite input.
+	moves_menu.hide()
+	message_box.hide()
+	get_viewport().gui_release_focus()
 	target_selector_ui.show_targets(candidates)
 
 	# Esperar a que se seleccione un target - await devuelve directamente el parámetro de la señal
@@ -785,6 +789,8 @@ func _in_hgss_summary_input_pause(paused: bool) -> void:
 
 ## Modal UI propia de batalla que también debe habilitar el ruteo de input global (DisplayManager).
 func has_modal_ui_visible() -> bool:
+	if target_selector_ui != null and target_selector_ui.visible:
+		return true
 	if _battle_move_forget_summary != null and _battle_move_forget_summary.visible:
 		return true
 	if _battle_bag_ui != null and _battle_bag_ui.visible:

--- a/Scripts/UI/PartyUI.gd
+++ b/Scripts/UI/PartyUI.gd
@@ -8,6 +8,8 @@ signal use_item_requested(slot_index: int)
 ## Flujo mochila → elegir Pokémon objetivo (sin menú de acciones).
 signal bag_item_target_selected(slot_index: int)
 signal bag_item_target_cancelled()
+signal battle_switch_slot_selected(slot_index: int)
+signal battle_switch_cancelled()
 
 const SLOT_COUNT: int = 6
 const CANCEL_INDEX: int = 6
@@ -30,6 +32,8 @@ var _in_hgss_summary: bool = false
 var _switch_mode: bool = false
 var _switch_origin_slot: int = -1
 var _bag_item_target_pick_mode: bool = false
+var _battle_switch_pick_mode: bool = false
+var _battle_force_switch: bool = false
 
 
 func _ready() -> void:
@@ -75,11 +79,23 @@ func open_for_bag_item_target_pick(initial_focus_slot: int = -1) -> void:
 	_open_party_common(initial_focus_slot, true)
 
 
+func open_for_battle_switch_pick(initial_focus_slot: int = -1, force_switch: bool = false) -> void:
+	_open_party_common(initial_focus_slot, false)
+	_battle_switch_pick_mode = true
+	_battle_force_switch = force_switch
+	if _battle_force_switch:
+		_set_help_text("Elige un Pokémon para continuar.")
+	else:
+		_set_help_text("Elige el Pokémon al que cambiar.")
+
+
 func _open_party_common(initial_focus_slot: int, bag_item_pick: bool) -> void:
 	if _controller == null:
 		push_error("PartyUI: Abre con setup(controller) antes.")
 		return
 	_bag_item_target_pick_mode = bag_item_pick
+	_battle_switch_pick_mode = false
+	_battle_force_switch = false
 	var requested_focus_slot: int = initial_focus_slot
 	_exit_switch_mode()
 	_in_hgss_summary = false
@@ -107,6 +123,8 @@ func close() -> void:
 	if not visible:
 		return
 	_bag_item_target_pick_mode = false
+	_battle_switch_pick_mode = false
+	_battle_force_switch = false
 	if summary.visible:
 		summary.hide()
 	_disable_input()
@@ -502,6 +520,12 @@ func _on_input_cancel() -> void:
 		# DisplayManager funde a negro y cierra (evita un frame a juego desnudo).
 		bag_item_target_cancelled.emit()
 		return
+	if _battle_switch_pick_mode:
+		if _battle_force_switch:
+			_set_help_text("Debes elegir un Pokémon válido.")
+			return
+		battle_switch_cancelled.emit()
+		return
 	if _switch_mode:
 		_exit_switch_mode()
 		_set_help_text("Elige a un Pokémon.")
@@ -512,6 +536,12 @@ func _on_input_cancel() -> void:
 func _on_input_start() -> void:
 	if _bag_item_target_pick_mode and _can_handle_party_input():
 		bag_item_target_cancelled.emit()
+		return
+	if _battle_switch_pick_mode and _can_handle_party_input():
+		if _battle_force_switch:
+			_set_help_text("Debes elegir un Pokémon válido.")
+			return
+		battle_switch_cancelled.emit()
 		return
 	if _switch_mode and _can_handle_party_input():
 		_exit_switch_mode()
@@ -533,6 +563,21 @@ func _handle_accept_async() -> void:
 		if not _controller.is_slot_occupied(slot):
 			return
 		bag_item_target_selected.emit(slot)
+		return
+
+	if _battle_switch_pick_mode:
+		if slot == CANCEL_INDEX:
+			if _battle_force_switch:
+				_set_help_text("Debes elegir un Pokémon válido.")
+			else:
+				battle_switch_cancelled.emit()
+			return
+		if slot < 0 or slot >= SLOT_COUNT:
+			return
+		if not _controller.is_slot_occupied(slot):
+			_set_help_text("No hay ningún Pokémon en ese slot.")
+			return
+		await _handle_battle_switch_choice_menu(slot)
 		return
 
 	if _switch_mode:
@@ -641,6 +686,35 @@ func _handle_accept_async() -> void:
 		&"cancel":
 			pass
 	_set_help_text("Elige a un Pokémon.")
+
+
+func _handle_battle_switch_choice_menu(slot: int) -> void:
+	var slot_view: Dictionary = _controller.get_slot_view(slot)
+	var mon_name: String = str(slot_view.get("display_name", "Pokémon"))
+	_set_help_text("¿Qué hacer con %s?" % mon_name)
+	_suppress_input = true
+	var idx: int = await DisplayManager.show_party_action_choices(["Cambio", "Datos", "Salir"])
+	_suppress_input = false
+
+	match idx:
+		0:
+			if _controller.has_method("is_selectable_switch_slot") and not _controller.is_selectable_switch_slot(slot):
+				var msg := "No puedes elegir ese Pokémon."
+				if _controller.has_method("get_invalid_switch_reason"):
+					msg = str(_controller.get_invalid_switch_reason(slot))
+				_set_help_text(msg)
+				return
+			battle_switch_slot_selected.emit(slot)
+			return
+		1:
+			await _open_hgss_summary(slot)
+			return
+		_:
+			if _battle_force_switch:
+				_set_help_text("Elige un Pokémon para continuar.")
+			else:
+				_set_help_text("Elige el Pokémon al que cambiar.")
+			return
 
 
 func _open_hgss_summary(slot: int) -> void:


### PR DESCRIPTION
### Party UI en combate (cambio de Pokémon)
- Apertura de Party desde el menú de acciones (**Pokémon**)
- Selección con validación: slot vacío, debilitado, ya en campo, no disponible en combate
- Cancelación vuelve al menú de acciones
- Generación de `BattleSwitchChoice` con salida, entrada, lado e índice de party
- Ejecución vía `BattleSwitchHandler` / `SwitchEffect` y actualización de UI de campo
- El cambio desde menú consume turno
- Nuevo `BattlePartySwitchController` (datos y validación para Party en batalla)
- Modo `open_for_battle_switch_pick` en `PartyUI` (menú Cambio / Datos / Salir)
- Preparación para cambio forzado (`force_switch`) sin flujo de juego enlazado aún

### Arquitectura de choices y turno
- `BattleChoice.pokemon` fijado al elegir; setter sincroniza `battle_spot`
- Omisión de acciones si el actor está debilitado o ausente antes de ejecutar (doble / velocidad)

### Combate doble y TestBattle
- Input en selección de objetivo: selector como modal en `DisplayManager`
- Corrección de crash al ejecutar el turno de un Pokémon ya debilitado
- `TestBattle`: bootstrap de `DisplayManager` al ejecutar la escena en solitario (F6)
- Party de prueba: jugador hasta 6; salvajes 1 (single) / 2 (double); trainer configurable

### Efectos, targeting y EXP (colateral)
- Veneno y quemadura al final del turno de combate (`ON_END_BATTLE_TURN`)
- Limpieza de efectos persistentes del Pokémon al salir del campo
- Targeting por `BattleSpot` (`Scope.SPOT`); ítems enemigos con `enemy_target_spot`
- EXP: animación de barra solo en Pokémon activo en campo tras KO
