### PR TITLE
Sistema de captura en combate e integración con Bag/Party (AB#347, AB#331, AB#326, AB#327) 

### DIFF
--- a/Resources/Data/Items/001 - Master Ball.tres
+++ b/Resources/Data/Items/001 - Master Ball.tres
@@ -3,6 +3,12 @@
 [ext_resource type="Script" uid="uid://bdxbue0jidsv7" path="res://Scripts/Resources/Classes/ItemData.gd" id="1_begtf"]
 [ext_resource type="Texture2D" uid="uid://dvs3t7asjewij" path="res://Sprites/Iconos/Items/items_atlas_000.png" id="1_jqbfu"]
 [ext_resource type="Resource" path="res://Resources/BattleCategories/Items/BattlePokeballItemCategory.tres" id="1_wy3wq"]
+[ext_resource type="Script" path="res://Scripts/Resources/Effects/PokeballItemEffect.gd" id="2_ball"]
+
+[sub_resource type="Resource" id="Resource_ballfx"]
+script = ExtResource("2_ball")
+guaranteed_capture = true
+capture_ball_modifier = 255.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_jqbfu"]
 atlas = ExtResource("1_jqbfu")
@@ -21,3 +27,4 @@ item_category_id = 34
 category = ExtResource("1_wy3wq")
 allowed_contexts = 4
 target_type = 1
+effect = SubResource("Resource_ballfx")

--- a/Resources/Data/Items/002 - Ultra Ball.tres
+++ b/Resources/Data/Items/002 - Ultra Ball.tres
@@ -3,6 +3,11 @@
 [ext_resource type="Script" uid="uid://bdxbue0jidsv7" path="res://Scripts/Resources/Classes/ItemData.gd" id="1_bqocj"]
 [ext_resource type="Resource" path="res://Resources/BattleCategories/Items/BattlePokeballItemCategory.tres" id="1_fqvnt"]
 [ext_resource type="Texture2D" uid="uid://dvs3t7asjewij" path="res://Sprites/Iconos/Items/items_atlas_000.png" id="1_nc6dh"]
+[ext_resource type="Script" path="res://Scripts/Resources/Effects/PokeballItemEffect.gd" id="2_ball"]
+
+[sub_resource type="Resource" id="Resource_ballfx"]
+script = ExtResource("2_ball")
+capture_ball_modifier = 2.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_nc6dh"]
 atlas = ExtResource("1_nc6dh")
@@ -21,3 +26,4 @@ item_category_id = 34
 category = ExtResource("1_fqvnt")
 allowed_contexts = 4
 target_type = 1
+effect = SubResource("Resource_ballfx")

--- a/Resources/Data/Items/003 - Super Ball.tres
+++ b/Resources/Data/Items/003 - Super Ball.tres
@@ -3,6 +3,11 @@
 [ext_resource type="Script" uid="uid://bdxbue0jidsv7" path="res://Scripts/Resources/Classes/ItemData.gd" id="1_4a8oy"]
 [ext_resource type="Texture2D" uid="uid://dvs3t7asjewij" path="res://Sprites/Iconos/Items/items_atlas_000.png" id="1_gfawm"]
 [ext_resource type="Resource" path="res://Resources/BattleCategories/Items/BattlePokeballItemCategory.tres" id="1_utqmm"]
+[ext_resource type="Script" path="res://Scripts/Resources/Effects/PokeballItemEffect.gd" id="2_ball"]
+
+[sub_resource type="Resource" id="Resource_ballfx"]
+script = ExtResource("2_ball")
+capture_ball_modifier = 1.5
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_gfawm"]
 atlas = ExtResource("1_gfawm")
@@ -21,3 +26,4 @@ item_category_id = 34
 category = ExtResource("1_utqmm")
 allowed_contexts = 4
 target_type = 1
+effect = SubResource("Resource_ballfx")

--- a/Resources/Data/Items/004 - Poké Ball.tres
+++ b/Resources/Data/Items/004 - Poké Ball.tres
@@ -3,6 +3,11 @@
 [ext_resource type="Script" uid="uid://bdxbue0jidsv7" path="res://Scripts/Resources/Classes/ItemData.gd" id="1_6xkgh"]
 [ext_resource type="Texture2D" uid="uid://dvs3t7asjewij" path="res://Sprites/Iconos/Items/items_atlas_000.png" id="1_vb8uj"]
 [ext_resource type="Resource" path="res://Resources/BattleCategories/Items/BattlePokeballItemCategory.tres" id="1_yd41b"]
+[ext_resource type="Script" path="res://Scripts/Resources/Effects/PokeballItemEffect.gd" id="2_ball"]
+
+[sub_resource type="Resource" id="Resource_ballfx"]
+script = ExtResource("2_ball")
+capture_ball_modifier = 1.0
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_vb8uj"]
 atlas = ExtResource("1_vb8uj")
@@ -21,3 +26,4 @@ item_category_id = 34
 category = ExtResource("1_yd41b")
 allowed_contexts = 4
 target_type = 1
+effect = SubResource("Resource_ballfx")

--- a/Resources/Data/Types/01.tres
+++ b/Resources/Data/Types/01.tres
@@ -13,5 +13,6 @@ script = ExtResource("2_niwsb")
 internal_name = "normal"
 Name = "Normal"
 id = 1
+no_effect_to = Array[int]([8])
 panelMove_y = null
 image = SubResource("AtlasTexture_fdbi1")

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -3,6 +3,8 @@ extends Node2D
 const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 
 @export_group("Equipos de prueba")
+## Si true, lanza un 1vs1 salvaje fijo: Rattata Nv.20 (jugador) vs Gastly Nv.20 (rival).
+@export var use_fixed_rattata_vs_gastly: bool = true
 ## Tamaño del party del jugador (1–6). En doble solo 2 salen al campo; el resto queda en banca para cambios.
 @export_range(1, 6) var test_player_party_size: int = 6
 ## Tamaño del party del entrenador rival (1–6) cuando se use singleTrainerBattle / trainers en escena.
@@ -24,8 +26,15 @@ var _bootstrapped_display_manager: DisplayManager = null
 func _ready() -> void:
 	if not await _ensure_display_manager():
 		return
-	_setup_test_battler_parties()
+	if use_fixed_rattata_vs_gastly:
+		_setup_fixed_rattata_gastly_parties()
+	else:
+		_setup_test_battler_parties()
 	_seed_test_capture_items()
+	if use_fixed_rattata_vs_gastly:
+		print(">>> Combate fijo: Rattata Nv.20 vs Gastly salvaje Nv.20")
+		await wildFixedRattataGastlyBattle()
+		return
 	# Lanzar combates en bucle para testing continuo
 	while true:
 		if randi() % 2 == 0:
@@ -34,9 +43,7 @@ func _ready() -> void:
 		else:
 			print(">>> Iniciando Double Wild Battle (Random)")
 			await wildRandomDoubleBattle()
-		# Pequeña pausa entre combates
 		await get_tree().create_timer(0.5).timeout
-	#get_tree().quit()
 
 
 ## Al ejecutar TestBattle.tscn directamente no existe Main/DisplayManager; lo creamos aquí.
@@ -107,6 +114,18 @@ func wildDoubleBattle():
 	var winner = await DisplayManager.start_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
+func wildFixedRattataGastlyBattle() -> void:
+	var player_participant: BattleParticipant = _create_fixed_player_participant(
+		PokemonsEnum.Values.RATTATA, 20
+	)
+	var wild_participant: BattleParticipant = _create_fixed_wild_participant(
+		PokemonsEnum.Values.GASTLY, 20
+	)
+	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.SINGLE)
+	var winner = await DisplayManager.start_battle([player_participant, wild_participant], rules)
+	print(">>> Batalla Rattata vs Gastly terminada. Ganador: %s" % winner)
+
+
 func wildRandomSingleBattle():
 	# Generar equipos completamente aleatorios para jugador y salvaje
 	var playerParticipant: BattleParticipant = _create_random_player_participant(test_player_party_size)
@@ -152,6 +171,16 @@ func singleTrainerBattle():
 	var winner = await DisplayManager.start_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
+## Party en escena para `player` / `wildPokemons` (combate fijo por battler opcional).
+func _setup_fixed_rattata_gastly_parties() -> void:
+	if player != null:
+		player.party.clear()
+		player.add_pokemon_to_party(_create_pokemon_instance(PokemonsEnum.Values.RATTATA, 20, false))
+	if wildPokemons != null:
+		wildPokemons.party.clear()
+		wildPokemons.add_pokemon_to_party(_create_pokemon_instance(PokemonsEnum.Values.GASTLY, 100, true))
+
+
 ## Rellena los Battler de escena para pruebas con party configurado en inspector.
 func _setup_test_battler_parties() -> void:
 	_fill_battler_random_party(player, test_player_party_size, false)
@@ -186,23 +215,34 @@ func _seed_test_capture_items() -> void:
 	bag.add_item(4, 10)  # Poké Ball
 	bag.add_item(3, 10)  # Super Ball
 	bag.add_item(2, 10)  # Ultra Ball
-	print("TestBattle: bolas de prueba añadidas (Poké x10, Super x10, Ultra x10).")
+	bag.add_item(17, 10)  # Poción
+	print("TestBattle: ítems de prueba en mochila (bolas x10, Poción x10).")
+
+
+func _create_pokemon_instance(species_id: int, level: int, is_wild: bool) -> Pokemon:
+	var pokemon_data = DatabaseService.get_pokemon(species_id)
+	var pkmn := Pokemon.new(pokemon_data, level, 0, 0, 0, true)
+	pkmn.is_wild = is_wild
+	return pkmn
+
+
+func _create_fixed_player_participant(species_id: int, level: int) -> BattleParticipant:
+	var team: Array[BattlePokemon] = [_create_pokemon_instance(species_id, level, false).to_battle_pokemon()]
+	var participant := BattleParticipant.new(team)
+	participant.is_player = true
+	participant.name = "Jugador"
+	return participant
+
+
+func _create_fixed_wild_participant(species_id: int, level: int) -> BattleParticipant:
+	var bp: BattlePokemon = _create_pokemon_instance(species_id, level, true).to_battle_pokemon()
+	bp.is_wild = true
+	return BattleParticipantWild.new([bp])
 
 
 # Helper: genera un Pokémon aleatorio (instancia persistente / party)
 func _create_random_pokemon_instance(is_wild: bool = false) -> Pokemon:
-	var random_id = randi_range(1, 151)
-	var pokemon_data = DatabaseService.get_pokemon(random_id)
-	var pkmn := Pokemon.new(
-		pokemon_data,
-		randi_range(1, 100),
-		0,
-		0,
-		0,
-		true
-	)
-	pkmn.is_wild = is_wild
-	return pkmn
+	return _create_pokemon_instance(randi_range(1, 151), randi_range(1, 100), is_wild)
 
 
 # Helper: genera un BattlePokemon aleatorio

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -25,6 +25,7 @@ func _ready() -> void:
 	if not await _ensure_display_manager():
 		return
 	_setup_test_battler_parties()
+	_seed_test_capture_items()
 	# Lanzar combates en bucle para testing continuo
 	while true:
 		if randi() % 2 == 0:
@@ -173,6 +174,19 @@ func _trim_battler_party(battler: Battler, max_size: int) -> void:
 		return
 	while battler.party.size() > max_size:
 		battler.party.pop_back()
+
+
+## Poké Balls para probar captura desde la mochila de combate (usa `GameStateService.bag`).
+func _seed_test_capture_items() -> void:
+	if GameStateService == null:
+		return
+	var bag = GameStateService.get_bag()
+	if bag == null:
+		return
+	bag.add_item(4, 10)  # Poké Ball
+	bag.add_item(3, 10)  # Super Ball
+	bag.add_item(2, 10)  # Ultra Ball
+	print("TestBattle: bolas de prueba añadidas (Poké x10, Super x10, Ultra x10).")
 
 
 # Helper: genera un Pokémon aleatorio (instancia persistente / party)

--- a/Scripts/Battle/core/Battle Choices/BattleBagChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleBagChoice.gd
@@ -43,9 +43,10 @@ func get_priority() -> int:
 	return 6
 
 func is_blocking_action() -> bool:
-	# Por defecto, usar objetos NO bloquea (pociones, bayas, etc.)
-	# TODO: Poké Balls → true (bloquean secuencia de turno).
-	return false
+	if item_id <= 0:
+		return false
+	var item_data: ItemData = DatabaseService.get_item_by_id(item_id)
+	return item_data != null and item_data.kind == ItemEnums.Kind.POKEBALL
 
 func resolve() -> Array[BattleHandler]:
 	var item_data: ItemData = DatabaseService.get_item_by_id(item_id)

--- a/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd
@@ -86,53 +86,19 @@ func visualize(ui: BattleUI) -> void:
 	if ui == null or result == null:
 		return
 
-	await ui.show_message_from_dict({
-		"type": "display",
-		"text": "¡%s lanzó una %s!" % [_actor_name(), _ball_name],
-		"wait_time": 0.9,
-	})
+	await _show_dialogue_line(ui, "¡%s usó %s!" % [_actor_name(), _ball_name], 0.9)
 
+	var shake_count := result.shakes
 	if ball_effect != null and ball_effect.guaranteed_capture:
-		await _show_shake_message(ui, 1)
-		await _show_shake_message(ui, 2)
-		await _show_shake_message(ui, 3)
-		await ui.show_message_from_dict({
-			"type": "display",
-			"text": "¡Ya está! ¡%s fue capturado!" % result.target_display_name,
-			"wait_time": 1.2,
-		})
-		return
+		shake_count = MAX_VISIBLE_SHAKES
+
+	await _show_shake_pauses(ui, shake_count)
 
 	if result.success:
-		for i in range(result.shakes):
-			await _show_shake_message(ui, i + 1)
-		await ui.show_message_from_dict({
-			"type": "display",
-			"text": "¡Ya está! ¡%s fue capturado!" % result.target_display_name,
-			"wait_time": 1.2,
-		})
+		await _show_success_dialogue(ui)
 		return
 
-	if result.is_early_fail():
-		await ui.show_message_from_dict({
-			"type": "display",
-			"text": "¡Oh no! El Pokémon se escapó de la %s." % _ball_name,
-			"wait_time": 1.0,
-		})
-		return
-
-	for i in range(result.shakes):
-		await _show_shake_message(ui, i + 1)
-	var fail_text: String
-	if result.failed_shake_index >= MAX_VISIBLE_SHAKES:
-		fail_text = "¡Oh! ¡%s estuvo a punto de atraparse!" % result.target_display_name
-	else:
-		fail_text = "¡Vaya! ¡%s se escapó!" % result.target_display_name
-	await ui.show_message_from_dict({
-		"type": "display",
-		"text": fail_text,
-		"wait_time": 1.0,
-	})
+	await _show_failure_dialogue(ui, result.shakes)
 
 
 func _actor_name() -> String:
@@ -144,14 +110,56 @@ func _actor_name() -> String:
 	return "El jugador"
 
 
-func _show_shake_message(ui: BattleUI, shake_number: int) -> void:
-	var text := "¡La %s se balancea %d vez!" % [_ball_name, shake_number]
-	if shake_number != 1:
-		text = "¡La %s se balancea %d veces!" % [_ball_name, shake_number]
+func _show_success_dialogue(ui: BattleUI) -> void:
+	var lines: Array[String] = ["¡Ya está!", "¡%s atrapado!" % result.target_display_name]
+	await _show_multiline_dialogue(ui, lines, 1.2)
+
+
+func _show_failure_dialogue(ui: BattleUI, completed_shakes: int) -> void:
+	await _show_multiline_dialogue(ui, _get_failure_lines(completed_shakes), 1.1)
+
+
+func _get_failure_lines(completed_shakes: int) -> Array[String]:
+	match completed_shakes:
+		0:
+			return ["¡Oh, no!", "¡El Pokémon se ha escapado!"]
+		1:
+			return ["¡Vaya!", "¡Parecía que lo habías atrapado!"]
+		2:
+			return ["¡Qué pena!", "¡Te faltó poco!"]
+		3:
+			return ["¡Huy!", "¡Casi lo consigues!"]
+		_:
+			return ["¡Oh, no!", "¡El Pokémon se ha escapado!"]
+
+
+func _show_shake_pauses(ui: BattleUI, shake_count: int) -> void:
+	for i in range(shake_count):
+		await _show_shake_pause(ui, i + 1)
+
+
+func _show_shake_pause(ui: BattleUI, shake_number: int) -> void:
+	print(_get_shake_log_text(shake_number))
+	await ui.get_tree().create_timer(0.85).timeout
+
+
+func _get_shake_log_text(shake_number: int) -> String:
+	if shake_number == 1:
+		return "¡La %s se balancea 1 vez!" % _ball_name
+	return "¡La %s se balancea %d veces!" % [_ball_name, shake_number]
+
+
+func _show_multiline_dialogue(ui: BattleUI, lines: Array[String], wait_time: float) -> void:
+	if lines.is_empty():
+		return
+	await _show_dialogue_line(ui, "\n".join(lines), wait_time)
+
+
+func _show_dialogue_line(ui: BattleUI, text: String, wait_time: float) -> void:
 	await ui.show_message_from_dict({
 		"type": "display",
 		"text": text,
-		"wait_time": 0.85,
+		"wait_time": wait_time,
 	})
 
 

--- a/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd
@@ -1,0 +1,212 @@
+extends ImmediateBattleEffect
+class_name CaptureEffect
+
+## Balanceos mostrados al jugador (checks 0–2). El check 3 solo determina captura.
+const MAX_VISIBLE_SHAKES := 3
+
+var target: BattlePokemon
+var ball_effect: PokeballItemEffect
+var result: CaptureResult = null
+
+var _ball_name: String = "Poké Ball"
+var _thrower_name: String = ""
+
+
+func _init(
+	_target: BattlePokemon,
+	_ball_effect: PokeballItemEffect,
+	_ball_display_name: String = "Poké Ball",
+	_thrower_display_name: String = ""
+) -> void:
+	target = _target
+	ball_effect = _ball_effect
+	_ball_name = _ball_display_name
+	_thrower_name = _thrower_display_name
+	result = CaptureResult.new()
+	result.target_display_name = _target.get_display_name() if _target != null else "Pokémon"
+	result.ball_display_name = _ball_name
+
+
+func apply() -> void:
+	result = CaptureResult.new()
+	result.target_display_name = target.get_display_name() if target != null else "Pokémon"
+	result.ball_display_name = _ball_name
+
+	if target == null or target.base_data == null or ball_effect == null:
+		result.success = false
+		result.failure_kind = CaptureResult.FailureKind.EARLY_FAIL
+		return
+
+	if ball_effect.guaranteed_capture:
+		result.success = true
+		result.shakes = MAX_VISIBLE_SHAKES
+		result.captured_pokemon = _clone_captured_pokemon(target)
+		return
+
+	var catch_rate: int = _resolve_species_capture_rate(target)
+	var max_hp: int = maxi(target.total_hp, 1)
+	var cur_hp: int = clampi(target.get_hp(), 1, max_hp)
+	var ball_mod: float = maxf(ball_effect.capture_ball_modifier, 0.1)
+
+	var a: float = (3.0 * float(max_hp) - 2.0 * float(cur_hp)) * float(catch_rate) * ball_mod
+	a /= 3.0 * float(max_hp)
+	a *= _status_capture_multiplier(target)
+
+	if a >= 255.0:
+		result.success = true
+		result.shakes = MAX_VISIBLE_SHAKES
+		result.captured_pokemon = _clone_captured_pokemon(target)
+		return
+
+	var b: int = _compute_shake_threshold(int(a))
+
+	# Checks 0–2: cada éxito = una sacudida visible (máximo 3).
+	for shake_idx in range(MAX_VISIBLE_SHAKES):
+		if _shake_check_fails(b):
+			result.success = false
+			result.shakes = shake_idx
+			result.failed_shake_index = shake_idx
+			result.failure_kind = CaptureResult.FailureKind.SHAKE_FAIL if shake_idx > 0 else CaptureResult.FailureKind.EARLY_FAIL
+			return
+
+	result.shakes = MAX_VISIBLE_SHAKES
+
+	# Check 3: determina si el Pokémon queda atrapado (sin 4.ª sacudida visual).
+	if _shake_check_fails(b):
+		result.success = false
+		result.failed_shake_index = MAX_VISIBLE_SHAKES
+		result.failure_kind = CaptureResult.FailureKind.SHAKE_FAIL
+		return
+
+	result.success = true
+	result.captured_pokemon = _clone_captured_pokemon(target)
+
+
+func visualize(ui: BattleUI) -> void:
+	if ui == null or result == null:
+		return
+
+	await ui.show_message_from_dict({
+		"type": "display",
+		"text": "¡%s lanzó una %s!" % [_actor_name(), _ball_name],
+		"wait_time": 0.9,
+	})
+
+	if ball_effect != null and ball_effect.guaranteed_capture:
+		await _show_shake_message(ui, 1)
+		await _show_shake_message(ui, 2)
+		await _show_shake_message(ui, 3)
+		await ui.show_message_from_dict({
+			"type": "display",
+			"text": "¡Ya está! ¡%s fue capturado!" % result.target_display_name,
+			"wait_time": 1.2,
+		})
+		return
+
+	if result.success:
+		for i in range(result.shakes):
+			await _show_shake_message(ui, i + 1)
+		await ui.show_message_from_dict({
+			"type": "display",
+			"text": "¡Ya está! ¡%s fue capturado!" % result.target_display_name,
+			"wait_time": 1.2,
+		})
+		return
+
+	if result.is_early_fail():
+		await ui.show_message_from_dict({
+			"type": "display",
+			"text": "¡Oh no! El Pokémon se escapó de la %s." % _ball_name,
+			"wait_time": 1.0,
+		})
+		return
+
+	for i in range(result.shakes):
+		await _show_shake_message(ui, i + 1)
+	var fail_text: String
+	if result.failed_shake_index >= MAX_VISIBLE_SHAKES:
+		fail_text = "¡Oh! ¡%s estuvo a punto de atraparse!" % result.target_display_name
+	else:
+		fail_text = "¡Vaya! ¡%s se escapó!" % result.target_display_name
+	await ui.show_message_from_dict({
+		"type": "display",
+		"text": fail_text,
+		"wait_time": 1.0,
+	})
+
+
+func _actor_name() -> String:
+	if not _thrower_name.is_empty():
+		return _thrower_name
+	var player_name := str(GameStateService.get_variable("PLAYER_NAME", "")).strip_edges()
+	if not player_name.is_empty():
+		return player_name
+	return "El jugador"
+
+
+func _show_shake_message(ui: BattleUI, shake_number: int) -> void:
+	var text := "¡La %s se balancea %d vez!" % [_ball_name, shake_number]
+	if shake_number != 1:
+		text = "¡La %s se balancea %d veces!" % [_ball_name, shake_number]
+	await ui.show_message_from_dict({
+		"type": "display",
+		"text": text,
+		"wait_time": 0.85,
+	})
+
+
+func _resolve_species_capture_rate(target_bp: BattlePokemon) -> int:
+	if target_bp == null or target_bp.base_data == null or target_bp.base_data.base == null:
+		return 45
+	var rate: int = int(target_bp.base_data.base.capture_rate)
+	if rate <= 0:
+		return 45
+	return clampi(rate, 1, 255)
+
+
+func _status_capture_multiplier(target_bp: BattlePokemon) -> float:
+	if target_bp == null or target_bp.base_data == null:
+		return 1.0
+	match target_bp.base_data.major_status:
+		CONST.STATUS.SLEEP, CONST.STATUS.FROZEN:
+			return 2.0
+		CONST.STATUS.POISON, CONST.STATUS.BURN, CONST.STATUS.PARALYSIS:
+			return 1.5
+		_:
+			return 1.0
+
+
+func _shake_check_fails(threshold: int) -> bool:
+	return randi() % 65536 >= threshold
+
+
+## Umbral S de Gen VI: 65536 / (255/M)^0.1875 (comparado con rand 0–65535).
+## La fórmula antigua (16711680 + mismo exponente) devolvía S > 65536 casi siempre → capturas triviales.
+func _compute_shake_threshold(modified_rate: int) -> int:
+	var m: int = clampi(modified_rate, 1, 255)
+	var ratio: float = 255.0 / float(m)
+	var denom: float = pow(ratio, 0.1875)
+	if denom <= 0.0:
+		return 65535
+	return mini(int(65536.0 / denom), 65535)
+
+
+func _clone_captured_pokemon(wild_bp: BattlePokemon) -> Pokemon:
+	if wild_bp == null or wild_bp.base_data == null:
+		return null
+	var serde := PokemonRuntimeSerde.new()
+	var data: Dictionary = wild_bp.base_data.to_serializable_state()
+	data["is_wild"] = false
+	var mon: Pokemon = serde.deserialize(data) as Pokemon
+	if mon == null:
+		return null
+	mon.is_wild = false
+	mon.capture_level = mon.level
+	mon.capture_date = Time.get_datetime_string_from_system(true, true)
+	var map_id := GameStateService.get_current_map_id()
+	if not map_id.is_empty():
+		mon.capture_route = map_id
+	var player_name := str(GameStateService.get_variable("PLAYER_NAME", "")).strip_edges()
+	if not player_name.is_empty():
+		mon.original_trainer = player_name
+	return mon

--- a/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Immediate/CaptureEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://c3jwbwb42jhla

--- a/Scripts/Battle/core/BattleTargetSelector.gd
+++ b/Scripts/Battle/core/BattleTargetSelector.gd
@@ -89,9 +89,31 @@ func resolve_targets(move: BattleMove, user: BattlePokemon, manual_target: Battl
 func requires_manual_selection(target_type: BattleTarget.TYPE, user: BattlePokemon) -> bool:
 	return target_type == BattleTarget.TYPE.SELECCIONAR and user.controllable
 
-## Obtiene los candidatos para selección manual (como BattleSpot para la UI)
-func get_selectable_spots(user: BattlePokemon) -> Array[BattleSpot]:
-	return _get_enemy_spots(user)
+## Cuadrícula para la UI: fila 0 = rivales, fila 1 = aliado (sin el usuario).
+func build_selection_grid(user: BattlePokemon, enemies_only: bool = false) -> TargetSelectionGrid:
+	var rows: Array = [_spots_sorted_by_index(_get_enemy_spots(user))]
+	if not enemies_only:
+		var allies: Array[BattleSpot] = []
+		for spot in _get_ally_spots(user):
+			if spot != user.battle_spot:
+				allies.append(spot)
+		allies = _spots_sorted_by_index(allies)
+		if not allies.is_empty():
+			rows.append(allies)
+	return TargetSelectionGrid.new(rows)
+
+
+## Lista plana de candidatos (auto-target 1 candidato, resolve_targets, etc.).
+func get_selectable_spots(user: BattlePokemon, enemies_only: bool = false) -> Array[BattleSpot]:
+	return build_selection_grid(user, enemies_only).all_spots()
+
+
+func _spots_sorted_by_index(spots: Array[BattleSpot]) -> Array[BattleSpot]:
+	var sorted := spots.duplicate()
+	sorted.sort_custom(func(a: BattleSpot, b: BattleSpot) -> bool:
+		return int(a.index) < int(b.index)
+	)
+	return sorted
 
 # ============================================================================
 # Métodos auxiliares privados (sin UI)

--- a/Scripts/Battle/core/BattleTargetSelectorUI.gd
+++ b/Scripts/Battle/core/BattleTargetSelectorUI.gd
@@ -3,68 +3,99 @@ class_name BattleTargetSelectorUI
 
 signal target_chosen(spot: BattleSpot)
 
-var spots: Array[BattleSpot] = []
-var current_index := 0
+var _grid: TargetSelectionGrid = null
 
-func _ready():
+
+func _ready() -> void:
 	call_deferred("_connect_display_manager_inputs")
 
-func show_targets(selectable_spots: Array[BattleSpot]) -> void:
-	spots = selectable_spots
-	current_index = 0
+
+func show_selection(grid: TargetSelectionGrid) -> void:
+	_grid = grid
 	visible = true
 	var dm := DisplayManager.instance
 	if dm and not dm.input_cancel.is_connected(_on_input_cancel):
 		dm.input_cancel.connect(_on_input_cancel)
+	_refresh_highlight()
 
-	_update_selector()
 
-func _on_input_left():
-	if not visible or spots.is_empty():
+func _refresh_highlight() -> void:
+	if _grid == null:
 		return
-	current_index = (current_index - 1 + spots.size()) % spots.size()
-	_update_selector()
+	var current := _grid.current_spot()
+	for spot in _grid.all_spots():
+		spot.highlight(spot == current)
 
-func _on_input_right():
-	if not visible or spots.is_empty():
-		return
-	current_index = (current_index + 1) % spots.size()
-	_update_selector()
 
-func _on_input_accept():
-	if not visible or spots.is_empty():
-		return
-	var chosen_spot = spots[current_index]
-	emit_signal("target_chosen", chosen_spot)
-	hide_selector()
-
-func _on_input_cancel():
-	if not visible or spots.is_empty():
-		return
-	hide_selector()
-	emit_signal("target_chosen", null)
-
-func _update_selector():
-	for i in spots.size():
-		spots[i].highlight(i == current_index)
-
-func hide_selector():
-	for spot in spots:
-		spot.highlight(false)
+func hide_selector() -> void:
+	if _grid != null:
+		for spot in _grid.all_spots():
+			spot.highlight(false)
 	var dm := DisplayManager.instance
 	if dm and dm.input_cancel.is_connected(_on_input_cancel):
 		dm.input_cancel.disconnect(_on_input_cancel)
+	_grid = null
 	visible = false
+
+
+func _on_input_left() -> void:
+	_nav_column(-1)
+
+
+func _on_input_right() -> void:
+	_nav_column(1)
+
+
+func _on_input_up() -> void:
+	_nav_row(-1)
+
+
+func _on_input_down() -> void:
+	_nav_row(1)
+
+
+func _nav_column(delta: int) -> void:
+	if not visible or _grid == null:
+		return
+	_grid.move_column(delta)
+	_refresh_highlight()
+
+
+func _nav_row(delta: int) -> void:
+	if not visible or _grid == null or not _grid.can_switch_row():
+		return
+	_grid.move_row(delta)
+	_refresh_highlight()
+
+
+func _on_input_accept() -> void:
+	if not visible or _grid == null:
+		return
+	var chosen := _grid.current_spot()
+	if chosen == null:
+		return
+	target_chosen.emit(chosen)
+	hide_selector()
+
+
+func _on_input_cancel() -> void:
+	if not visible:
+		return
+	hide_selector()
+	target_chosen.emit(null)
+
 
 func _connect_display_manager_inputs() -> void:
 	var dm := DisplayManager.instance
 	if not dm:
 		call_deferred("_connect_display_manager_inputs")
 		return
-
-	if not dm.input_left.is_connected(_on_input_left):
-		dm.input_left.connect(_on_input_left)
-	if not dm.input_right.is_connected(_on_input_right):
-		dm.input_right.connect(_on_input_right)
-	if not dm.input_accept.is_connected(_on_input_accept):
-		dm.input_accept.connect(_on_input_accept)
+	for sig: Dictionary in [
+		{"signal": dm.input_left, "callable": _on_input_left},
+		{"signal": dm.input_right, "callable": _on_input_right},
+		{"signal": dm.input_up, "callable": _on_input_up},
+		{"signal": dm.input_down, "callable": _on_input_down},
+		{"signal": dm.input_accept, "callable": _on_input_accept},
+	]:
+		if not sig.signal.is_connected(sig.callable):
+			sig.signal.connect(sig.callable)

--- a/Scripts/Battle/core/Capture/CaptureResult.gd
+++ b/Scripts/Battle/core/Capture/CaptureResult.gd
@@ -1,0 +1,27 @@
+extends RefCounted
+class_name CaptureResult
+
+enum FailureKind {
+	NONE,
+	EARLY_FAIL,
+	SHAKE_FAIL,
+}
+
+var success: bool = false
+## Sacudidas visibles completadas (0–3). La 4.ª comprobación solo decide captura.
+var shakes: int = 0
+## Índice de comprobación en la que falló (0–3; 3 = fallo tras 3 balanceos).
+var failed_shake_index: int = -1
+var failure_kind: FailureKind = FailureKind.NONE
+## Instancia lista para persistencia (solo si success).
+var captured_pokemon: Pokemon = null
+var target_display_name: String = ""
+var ball_display_name: String = ""
+
+
+func is_early_fail() -> bool:
+	return not success and failure_kind == FailureKind.EARLY_FAIL
+
+
+func is_shake_fail() -> bool:
+	return not success and failure_kind == FailureKind.SHAKE_FAIL

--- a/Scripts/Battle/core/Capture/CaptureResult.gd.uid
+++ b/Scripts/Battle/core/Capture/CaptureResult.gd.uid
@@ -1,0 +1,1 @@
+uid://brj6x0tgwg68n

--- a/Scripts/Battle/core/Categories/BattlePokeballItemCategory.gd
+++ b/Scripts/Battle/core/Categories/BattlePokeballItemCategory.gd
@@ -4,4 +4,4 @@ class_name BattlePokeballItemCategory
 
 
 func _create_handler(choice: BattleBagChoice, item_data: ItemData) -> BattleHandler:
-	return BattleUnsupportedItemHandler.new(choice, item_data)
+	return BattlePokeballItemHandler.new(choice, item_data)

--- a/Scripts/Battle/core/Controllers/BattleController.gd
+++ b/Scripts/Battle/core/Controllers/BattleController.gd
@@ -18,6 +18,8 @@ var sides: Array[BattleSide]
 
 var finished := false
 var winner_side: String = ""
+## Resultado de captura exitosa (persistencia al cerrar combate).
+var successful_capture: CaptureResult = null
 
 func _ready():
 	pass
@@ -168,6 +170,32 @@ func assign_opponent_sides():
 	sides[0].opponent_side = sides[1]
 	sides[1].opponent_side = sides[0]
 
+func register_successful_capture(capture_result: CaptureResult, target_bp: BattlePokemon = null) -> void:
+	if capture_result == null or not capture_result.success:
+		return
+	successful_capture = capture_result
+	finished = true
+	winner_side = "capture"
+	# La limpieza visual del rival se aplaza a tras la secuencia de captura (véase `apply_capture_field_cleanup`).
+
+
+## Retira al salvaje del campo tras la animación/mensajes de captura (no en `apply()` del handler).
+func apply_capture_field_cleanup(target_bp: BattlePokemon = null) -> void:
+	_remove_captured_wild_from_field(target_bp)
+
+
+func _remove_captured_wild_from_field(target_bp: BattlePokemon) -> void:
+	if target_bp != null and target_bp.battle_spot != null:
+		target_bp.battle_spot.remove_pokemon()
+		return
+	if enemy_side == null:
+		return
+	for spot in enemy_side.battle_spots:
+		if spot != null and spot.pokemon != null and spot.pokemon.is_wild:
+			spot.remove_pokemon()
+			return
+
+
 func battle_finished() -> bool:
 	# Si ya se determinó el fin, no recalcular
 	if finished:
@@ -201,6 +229,9 @@ func end_battle() -> void:
 	if not finished:
 		battle_finished()
 
+	if winner_side == "capture" and successful_capture != null:
+		await _finalize_successful_capture()
+
 	if !winner_side.is_empty():
 		# Mostrar mensaje de final de combate
 		await ui.show_battle_end_message(winner_side, rules, enemy_side.participants)
@@ -217,6 +248,8 @@ func end_battle() -> void:
 			result_msg = "Resultado del combate: gana Enemy"
 		"draw":
 			result_msg = "Resultado del combate: empate"
+		"capture":
+			result_msg = "Resultado del combate: captura exitosa"
 	print(result_msg)
 
 	# Guardar el ganador antes de limpiar el estado
@@ -360,10 +393,28 @@ func _mirror_player_party_to_gamestate(participant: BattleParticipant) -> void:
 				gs_mv.pp_actual = clampi(rt_mv.pp_actual, 0, gs_mv.pp)
 
 
+func _finalize_successful_capture() -> void:
+	if successful_capture == null or successful_capture.captured_pokemon == null:
+		return
+	var registration: Dictionary = CaptureRegistrationService.register_captured_pokemon(
+		successful_capture.captured_pokemon
+	)
+	var message: String = str(registration.get("message", ""))
+	if message.is_empty():
+		return
+	await ui.show_message_from_dict({
+		"type": "input",
+		"text": message,
+		"wait_time": 0.0,
+		"showIconAtEnd": true,
+	})
+
+
 func _cleanup_battle_state():
 	# Resetear flags de control
 	finished = false
 	winner_side = ""
+	successful_capture = null
 
 	# Resetear controlador de turnos
 	turn_controller.reset()

--- a/Scripts/Battle/core/Handlers/BattleItemHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattleItemHandler.gd
@@ -123,3 +123,16 @@ static func build_player_battle_item_context(choice: BattleBagChoice, target_bat
 		choice.pokemon,
 		target_battle_pokemon
 	)
+
+
+static func get_player_trainer_display_name(choice: BattleBagChoice) -> String:
+	if choice != null and choice.battle_controller != null and choice.battle_controller.player_side != null:
+		var trainer_names: Array[String] = choice.battle_controller.player_side.get_trainer_names()
+		if not trainer_names.is_empty():
+			var from_side := str(trainer_names[0]).strip_edges()
+			if not from_side.is_empty():
+				return from_side
+	var player_name := str(GameStateService.get_variable("PLAYER_NAME", "")).strip_edges()
+	if not player_name.is_empty():
+		return player_name
+	return "El jugador"

--- a/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd
@@ -1,0 +1,85 @@
+extends BattleItemHandler
+
+class_name BattlePokeballItemHandler
+
+var _choice: BattleBagChoice = null
+var _item_data: ItemData = null
+var _runtime_capture: CaptureEffect = null
+var _target_bp: BattlePokemon = null
+
+
+func _init(choice: BattleBagChoice, item_data: ItemData) -> void:
+	_choice = choice
+	_item_data = item_data
+
+
+func _apply() -> void:
+	_runtime_capture = null
+	_target_bp = null
+	item_use_result = null
+
+	if _choice == null or _choice.battle_controller == null or _choice.pokemon == null:
+		item_use_result = ItemUseResult.failure_error("Contexto de combate incompleto.")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+
+	if _item_data == null:
+		item_use_result = ItemUseResult.failure_error("Objeto desconocido.")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+
+	var target_bp: BattlePokemon = _choice.resolve_item_target_battle_pokemon()
+	if target_bp == null:
+		item_use_result = ItemUseResult.failure_blocked("No hay un Pokémon salvaje capturable.")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+	_target_bp = target_bp
+
+	var ctx: ItemUseContext = BattleItemHandler.build_player_battle_item_context(_choice, target_bp)
+	var ball_eff: PokeballItemEffect = PokeballItemEffect.resolve_for_item(_item_data)
+	if ball_eff == null:
+		item_use_result = ItemUseResult.failure_error("Ítem sin efecto de captura válido.")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+
+	item_use_result = ball_eff.apply(ctx)
+	if item_use_result == null:
+		item_use_result = ItemUseResult.failure_error("El efecto de captura devolvió un resultado inválido.")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+
+	if not item_use_result.success:
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+		return
+
+	var ball_name: String = _item_data.get_display_name()
+	var thrower_name: String = _choice.pokemon.get_display_name() if _choice.pokemon != null else ""
+	_runtime_capture = CaptureEffect.new(target_bp, ball_eff, ball_name, thrower_name)
+	_runtime_capture.apply()
+	var capture_result: CaptureResult = _runtime_capture.result
+
+	_consume_from_bag_if_needed(_item_data, item_use_result)
+
+	if capture_result != null and capture_result.success:
+		_choice.battle_controller.register_successful_capture(capture_result, target_bp)
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.BLOCKING_SEQUENCE
+		item_use_result.effect_data["capture_result"] = capture_result
+	else:
+		item_use_result = ItemUseResult.failure_no_effect("")
+		item_use_result.battle_continuation = ItemUseResult.BattleContinuation.COMPLETE_ACTION
+
+
+func _visualize(ui: BattleUI) -> void:
+	if item_use_result == null:
+		return
+	if _runtime_capture != null:
+		await show_item_used_battle_message(ui, _item_data)
+		await _runtime_capture.visualize(ui)
+		if item_use_result.battle_continuation == ItemUseResult.BattleContinuation.BLOCKING_SEQUENCE:
+			_choice.battle_controller.apply_capture_field_cleanup(_target_bp)
+		return
+	if item_use_result.outcome in [ItemUseResult.Outcome.BLOCKED, ItemUseResult.Outcome.ERROR]:
+		await show_battle_result_message(ui, item_use_result)
+		return
+	if not item_use_result.message.is_empty():
+		await show_battle_result_message(ui, item_use_result)

--- a/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd
@@ -53,7 +53,7 @@ func _apply() -> void:
 		return
 
 	var ball_name: String = _item_data.get_display_name()
-	var thrower_name: String = _choice.pokemon.get_display_name() if _choice.pokemon != null else ""
+	var thrower_name: String = BattleItemHandler.get_player_trainer_display_name(_choice)
 	_runtime_capture = CaptureEffect.new(target_bp, ball_eff, ball_name, thrower_name)
 	_runtime_capture.apply()
 	var capture_result: CaptureResult = _runtime_capture.result
@@ -73,7 +73,6 @@ func _visualize(ui: BattleUI) -> void:
 	if item_use_result == null:
 		return
 	if _runtime_capture != null:
-		await show_item_used_battle_message(ui, _item_data)
 		await _runtime_capture.visualize(ui)
 		if item_use_result.battle_continuation == ItemUseResult.BattleContinuation.BLOCKING_SEQUENCE:
 			_choice.battle_controller.apply_capture_field_cleanup(_target_bp)

--- a/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/BattlePokeballItemHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://c3tcsj4h6outf

--- a/Scripts/Battle/core/TargetSelectionGrid.gd
+++ b/Scripts/Battle/core/TargetSelectionGrid.gd
@@ -1,0 +1,54 @@
+extends RefCounted
+class_name TargetSelectionGrid
+
+## Filas de spots: [0] rivales (izq/der), [1] aliados si existe (arriba/abajo entre filas).
+var rows: Array = []
+var field_index: int = 0
+var column_index: int = 0
+
+
+func _init(p_rows: Array) -> void:
+	rows = p_rows
+	field_index = 0
+	column_index = 0
+
+
+func can_switch_row() -> bool:
+	return rows.size() > 1
+
+
+func current_spot() -> BattleSpot:
+	if rows.is_empty():
+		return null
+	var row: Array = rows[field_index]
+	if row.is_empty():
+		return null
+	column_index = clampi(column_index, 0, row.size() - 1)
+	return row[column_index] as BattleSpot
+
+
+func move_column(delta: int) -> void:
+	if rows.is_empty():
+		return
+	var row: Array = rows[field_index]
+	if row.size() <= 1:
+		return
+	column_index = (column_index + delta + row.size()) % row.size()
+
+
+func move_row(delta: int) -> void:
+	if not can_switch_row():
+		return
+	field_index = clampi(field_index + delta, 0, rows.size() - 1)
+	var row: Array = rows[field_index]
+	column_index = clampi(column_index, 0, maxi(row.size() - 1, 0))
+
+
+func all_spots() -> Array[BattleSpot]:
+	var out: Array[BattleSpot] = []
+	for row in rows:
+		for spot in row:
+			var bp_spot := spot as BattleSpot
+			if bp_spot != null and not out.has(bp_spot):
+				out.append(bp_spot)
+	return out

--- a/Scripts/Battle/core/TargetSelectionGrid.gd.uid
+++ b/Scripts/Battle/core/TargetSelectionGrid.gd.uid
@@ -1,0 +1,1 @@
+uid://r1pnkfebvxa1

--- a/Scripts/Battle/core/Utils/TypeEffectivenessUtils.gd
+++ b/Scripts/Battle/core/Utils/TypeEffectivenessUtils.gd
@@ -6,7 +6,11 @@ static func get_multiplier(attack_type: TypeData, def_type1: TypeData, def_type2
 	return mult1 * mult2
 
 static func _get_vs(attack_type: TypeData, defense_type: TypeData) -> float:
-	return attack_type.get_effectiveness_against(defense_type)
+	if attack_type == null or defense_type == null:
+		return 1.0
+	var outgoing := attack_type.get_effectiveness_against(defense_type)
+	var incoming := defense_type.get_effectiveness_from(attack_type)
+	return outgoing * incoming
 	#if defense_type in attack_type.no_effect_to:
 		#return 0.0
 	#if defense_type in attack_type.super_effective:

--- a/Scripts/Battle/ui/BattleMessageController.gd
+++ b/Scripts/Battle/ui/BattleMessageController.gd
@@ -394,6 +394,8 @@ func get_switch_message(trainer_name: String, pokemon_name: String) -> Dictionar
 # Mensajes de final de combate
 func get_battle_end_message(winner_side: String, rules: BattleRules, enemy_participants: Array) -> Dictionary:
 	match winner_side:
+		"capture":
+			return {}
 		"player":
 			# En combates salvajes, no se muestra mensaje al ganar
 			if rules.type == BattleRules.BattleTypes.WILD:

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -229,6 +229,16 @@ func show_bag_item_selection(pokemon: BattlePokemon) -> BattleChoice:
 		if selected_item_data == null:
 			continue
 
+		if selected_item_data.kind == ItemEnums.Kind.POKEBALL:
+			if battle_controller.rules == null or battle_controller.rules.type != BattleRules.BattleTypes.WILD:
+				await DisplayManager.show_message("¡No puedes capturar el Pokémon de otro entrenador!", {
+					"waitInput": true,
+					"closeAtEnd": true,
+					"frameStyle": MessageBoxFrameStyle.Values.HGSS,
+					"typingMode": "typing",
+				})
+				continue
+
 		if _battle_item_needs_ally_party_pick(selected_item_data):
 			var last_party_focus_slot: int = -1
 			while true:
@@ -256,6 +266,10 @@ func show_bag_item_selection(pokemon: BattlePokemon) -> BattleChoice:
 					_battle_bag_ui.open()
 				continue
 			out.enemy_target_spot = foe_spot
+			if not await _is_pokeball_choice_usable(pokemon, selected_item_data, out):
+				if _battle_bag_ui != null and not _battle_bag_ui.visible:
+					_battle_bag_ui.open()
+				continue
 			return out
 		else:
 			_battle_bag_ui.close()
@@ -385,6 +399,33 @@ func show_party_item_result_and_close(message_text: String, target_party_slot: i
 		_battle_bag_ui.set_input_enabled(true)
 
 
+func _is_pokeball_choice_usable(_actor: BattlePokemon, item_data: ItemData, choice: BattleBagChoice) -> bool:
+	if item_data == null or item_data.kind != ItemEnums.Kind.POKEBALL:
+		return true
+	var ball_eff: PokeballItemEffect = PokeballItemEffect.resolve_for_item(item_data)
+	if ball_eff == null:
+		return false
+	var target_bp: BattlePokemon = choice.resolve_item_target_battle_pokemon()
+	if target_bp == null:
+		await DisplayManager.show_message("No hay un Pokémon salvaje capturable.", {
+			"waitInput": true,
+			"closeAtEnd": true,
+			"frameStyle": MessageBoxFrameStyle.Values.HGSS,
+			"typingMode": "typing",
+		})
+		return false
+	var ctx: ItemUseContext = BattleItemHandler.build_player_battle_item_context(choice, target_bp)
+	if ball_eff.can_use(ctx):
+		return true
+	await DisplayManager.show_message("No hay un Pokémon salvaje capturable.", {
+		"waitInput": true,
+		"closeAtEnd": true,
+		"frameStyle": MessageBoxFrameStyle.Values.HGSS,
+		"typingMode": "typing",
+	})
+	return false
+
+
 func _is_item_usable_on_party_slot_in_battle(actor: BattlePokemon, item_data: ItemData, item_id: int, slot: int) -> bool:
 	if item_data == null:
 		return false
@@ -459,7 +500,7 @@ func _reset_bag_ui_after_party_cancel() -> void:
 
 
 func _pick_enemy_target_spot_for_item(actor: BattlePokemon) -> BattleSpot:
-	var spot: BattleSpot = await show_target_selection(actor)
+	var spot: BattleSpot = await show_target_selection(actor, true)
 	if spot == null:
 		return null
 	if not spot.has_active_pokemon():
@@ -563,20 +604,17 @@ func show_move_selection(pokemon: BattlePokemon) -> BattleMoveChoice:
 	return move_choice
 
 
-func show_target_selection(user: BattlePokemon) -> BattleSpot:
-	# Obtener los spots seleccionables con la lógica
-	var candidates: Array[BattleSpot] = []
-	if target_selector != null:
-		candidates = target_selector.get_selectable_spots(user)
-
+func show_target_selection(user: BattlePokemon, enemies_only: bool = false) -> BattleSpot:
+	if target_selector == null:
+		return null
+	var grid: TargetSelectionGrid = target_selector.build_selection_grid(user, enemies_only)
+	var candidates: Array[BattleSpot] = grid.all_spots()
 	if candidates.size() == 1:
 		return candidates[0]
 
-	# El menú de movimientos puede conservar foco; sin modal visible DisplayManager no emite input.
-	moves_menu.hide()
 	message_box.hide()
 	get_viewport().gui_release_focus()
-	target_selector_ui.show_targets(candidates)
+	target_selector_ui.show_selection(grid)
 
 	# Esperar a que se seleccione un target - await devuelve directamente el parámetro de la señal
 	var selected_spot: BattleSpot = await target_selector_ui.target_chosen

--- a/Scripts/Resources/Classes/TypeData.gd
+++ b/Scripts/Resources/Classes/TypeData.gd
@@ -71,11 +71,7 @@ func get_effectiveness_against(type) -> float:
 	return 1.0
 
 func get_effectiveness_against_pokemon(pokemon: BattlePokemon) -> float:
-	var t1 = pokemon.get_type1()
-	var t2 = pokemon.get_type2()
-	var eff1 = get_effectiveness_against(t1)
-	var eff2 = get_effectiveness_against(t2) if t2 != null and t2 != t1 else 1.0
-	return eff1 * eff2
+	return TypeEffectivenessUtils.get_multiplier(self, pokemon.get_type1(), pokemon.get_type2())
 
 
 func _to_string() -> String:

--- a/Scripts/Resources/Effects/PokeballItemEffect.gd
+++ b/Scripts/Resources/Effects/PokeballItemEffect.gd
@@ -1,0 +1,75 @@
+extends ItemEffect
+class_name PokeballItemEffect
+
+## Multiplicador de la fórmula de captura (Poké Ball = 1.0, Super = 1.5, Ultra = 2.0, etc.).
+@export_range(0.1, 4.0, 0.1) var capture_ball_modifier: float = 1.0
+## Captura garantizada (Master Ball).
+@export var guaranteed_capture: bool = false
+
+
+static func resolve_for_item(item_data: ItemData) -> PokeballItemEffect:
+	if item_data == null:
+		return null
+	if item_data.effect is PokeballItemEffect:
+		return item_data.effect as PokeballItemEffect
+	return _create_default_for_item(item_data)
+
+
+static func _create_default_for_item(item_data: ItemData) -> PokeballItemEffect:
+	var eff := PokeballItemEffect.new()
+	var name_key := item_data.internal_name.to_lower()
+	eff.guaranteed_capture = name_key == "master-ball"
+	eff.capture_ball_modifier = _default_modifier_for_name(name_key)
+	return eff
+
+
+static func _default_modifier_for_name(internal_name: String) -> float:
+	match internal_name:
+		"great-ball":
+			return 1.5
+		"ultra-ball":
+			return 2.0
+		"master-ball":
+			return 255.0
+		_:
+			return 1.0
+
+
+func can_use(context: ItemUseContext) -> bool:
+	if not context.is_battle_use():
+		return false
+	if context.battle_controller == null or context.battle_controller.rules == null:
+		return false
+	if context.battle_controller.rules.type != BattleRules.BattleTypes.WILD:
+		return false
+	return _is_capturable_target(context)
+
+
+func apply(context: ItemUseContext) -> ItemUseResult:
+	var outside := context.failure_if_not_battle_use()
+	if outside != null:
+		return outside
+
+	var battle_err := require_battle_runtime(context)
+	if battle_err != null:
+		return battle_err
+
+	if context.battle_controller.rules.type != BattleRules.BattleTypes.WILD:
+		return ItemUseResult.failure_blocked("¡No puedes capturar el Pokémon de otro entrenador!")
+
+	if not _is_capturable_target(context):
+		return ItemUseResult.failure_blocked("No hay un Pokémon salvaje capturable.")
+
+	return ItemUseResult.success_result(1, "", {
+		"capture_ball_modifier": capture_ball_modifier,
+		"guaranteed_capture": guaranteed_capture,
+	})
+
+
+func _is_capturable_target(context: ItemUseContext) -> bool:
+	var target_bp: BattlePokemon = context.target_battle_pokemon
+	if target_bp == null or target_bp.base_data == null:
+		return false
+	if target_bp.is_fainted():
+		return false
+	return target_bp.is_wild

--- a/Scripts/Resources/Effects/PokeballItemEffect.gd.uid
+++ b/Scripts/Resources/Effects/PokeballItemEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://82f2sfmscfce

--- a/Scripts/Services/CaptureRegistrationService.gd
+++ b/Scripts/Services/CaptureRegistrationService.gd
@@ -1,0 +1,42 @@
+extends RefCounted
+class_name CaptureRegistrationService
+
+enum Destination {
+	PARTY,
+	PC,
+	PENDING_STORAGE,
+}
+
+## Registra un Pokémon capturado en party, PC o cola temporal.
+static func register_captured_pokemon(pokemon: Pokemon) -> Dictionary:
+	if pokemon == null:
+		return {
+			"ok": false,
+			"destination": Destination.PENDING_STORAGE,
+			"message": "No se pudo registrar el Pokémon capturado.",
+		}
+
+	pokemon.is_wild = false
+	var party_controller := PartyController.new()
+	var display_name: String = pokemon.get_display_name()
+
+	if party_controller.add_pokemon(pokemon):
+		return {
+			"ok": true,
+			"destination": Destination.PARTY,
+			"message": "¡%s se añadió a tu equipo!" % display_name,
+		}
+
+	if party_controller.send_to_pc(pokemon):
+		return {
+			"ok": true,
+			"destination": Destination.PC,
+			"message": "¡%s fue enviado al PC!" % display_name,
+		}
+
+	GameStateService.add_pending_pc_pokemon(pokemon)
+	return {
+		"ok": true,
+		"destination": Destination.PENDING_STORAGE,
+		"message": "¡%s fue guardado en espera (PC no disponible aún)." % display_name,
+	}

--- a/Scripts/Services/CaptureRegistrationService.gd.uid
+++ b/Scripts/Services/CaptureRegistrationService.gd.uid
@@ -1,0 +1,1 @@
+uid://bl21i78m4lw6x

--- a/Scripts/UI/BagUI.gd
+++ b/Scripts/UI/BagUI.gd
@@ -64,6 +64,8 @@ var _arrow_anim_time: float = 0.0
 var _item_icon_back_texture: Texture2D = null
 ## Índice seleccionado recordado por bolsillo (clave = ItemEnums.Pocket). -1 = aún no visitado.
 var _pocket_list_index_by_pocket: Dictionary = {}
+## Última posición de la mochila (bolsillo + cursor por bolsillo) entre aperturas en la misma sesión.
+static var _session_navigation: Dictionary = {}
 
 func _ready() -> void:
 	process_mode = Node.PROCESS_MODE_ALWAYS
@@ -89,9 +91,6 @@ func setup(controller) -> void:
 		return
 	_controller = controller
 	_pockets = _controller.get_pockets() if _controller else []
-	_current_pocket_index = 0
-	_selected_item_index = 0
-	_pocket_list_index_by_pocket.clear()
 
 
 func get_navigation_state() -> Dictionary:
@@ -115,6 +114,20 @@ func restore_navigation_state(state: Dictionary) -> void:
 	var remembered = state.get("pocket_list_index_by_pocket", {})
 	_pocket_list_index_by_pocket = remembered.duplicate(true) if remembered is Dictionary else {}
 
+
+func _apply_session_navigation() -> void:
+	if _session_navigation.is_empty():
+		_current_pocket_index = 0
+		_selected_item_index = 0
+		_pocket_list_index_by_pocket.clear()
+		return
+	restore_navigation_state(_session_navigation)
+
+
+func _persist_session_navigation() -> void:
+	_track_current_pocket_selection()
+	_session_navigation = get_navigation_state()
+
 func open() -> void:
 	if _controller == null:
 		push_error("BagUI: No se puede abrir sin controller. Llama setup(controller) primero.")
@@ -123,6 +136,7 @@ func open() -> void:
 	show()
 	_arrow_anim_time = 0.0
 	set_process(true)
+	_apply_session_navigation()
 	_refresh_current_pocket()
 	_enable_input()
 	_block_player_control()
@@ -131,6 +145,7 @@ func close() -> void:
 	if not visible:
 		return
 
+	_persist_session_navigation()
 	_disable_input()
 	set_process(false)
 	_reset_arrow_frames()

--- a/Services/GameStateService.gd
+++ b/Services/GameStateService.gd
@@ -63,6 +63,9 @@ var bag = BAG_SCRIPT.new()
 # Equipo del jugador (máx. 6 Pokémon); sin dependencia de UI
 var party = PARTY_SCRIPT.new()
 
+## Pokémon capturados en espera de PC (fallback cuando el almacenamiento no está listo).
+var pending_pc_pokemon: Array[Dictionary] = []
+
 # Pokédex global del jugador (por species_id)
 var pokedex = POKEDEX_SCRIPT.new()
 var unlocked_pokedex_ids: Array[String] = []
@@ -90,6 +93,7 @@ func initialize_new_game() -> void:
 	set_respawn_point(current_map_id, current_position, facing_dir)
 	bag = BAG_SCRIPT.new()
 	party = PARTY_SCRIPT.new()
+	pending_pc_pokemon.clear()
 	pokedex = POKEDEX_SCRIPT.new()
 	unlocked_pokedex_ids = ["kanto", "updated-johto", "national"]
 	active_pokedex_id = "kanto"
@@ -563,6 +567,28 @@ func load_party_save_data(entries: Array[Dictionary]) -> void:
 	get_party().load_serializable_data(entries)
 
 
+func add_pending_pc_pokemon(pokemon: Pokemon) -> void:
+	if pokemon == null:
+		return
+	pending_pc_pokemon.append(pokemon.to_serializable_state())
+	print("GameStateService: Pokémon en cola de PC pendiente (total=%d)." % pending_pc_pokemon.size())
+
+
+func get_pending_pc_pokemon_count() -> int:
+	return pending_pc_pokemon.size()
+
+
+func get_pending_pc_pokemon_save_data() -> Array[Dictionary]:
+	return pending_pc_pokemon.duplicate(true)
+
+
+func load_pending_pc_pokemon_save_data(entries: Array[Dictionary]) -> void:
+	pending_pc_pokemon.clear()
+	for entry in entries:
+		if entry is Dictionary:
+			pending_pc_pokemon.append(entry)
+
+
 ## Serializa la Pokédex para guardado futuro.
 func get_pokedex_save_data() -> Dictionary:
 	return get_pokedex().to_serializable_data()
@@ -739,6 +765,7 @@ func _build_save_payload() -> Dictionary:
 			"facing": _vector2_to_dict(_variant_to_vector2(rp.get("facing", facing_dir), facing_dir)),
 		},
 		"party": get_party_save_data(),
+		"pending_pc_pokemon": get_pending_pc_pokemon_save_data(),
 		"bag": get_bag_save_data(),
 		"pokedex": get_pokedex_save_data(),
 		"pokedex_registry": get_pokedex_registry_save_data(),
@@ -794,6 +821,16 @@ func _apply_save_payload(save_data: Dictionary) -> void:
 		load_party_save_data(safe_party_entries)
 	else:
 		load_party_save_data([])
+
+	var pending_pc_any: Variant = save_data.get("pending_pc_pokemon", [])
+	if pending_pc_any is Array:
+		var safe_pending: Array[Dictionary] = []
+		for entry_any in pending_pc_any:
+			if entry_any is Dictionary:
+				safe_pending.append(entry_any)
+		load_pending_pc_pokemon_save_data(safe_pending)
+	else:
+		load_pending_pc_pokemon_save_data([])
 
 	var pokedex_any: Variant = save_data.get("pokedex", {})
 	var raw_pokedex: Dictionary = pokedex_any if pokedex_any is Dictionary else {}


### PR DESCRIPTION
## PBIs incluidos

### [AB#347](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/347) — Efecto de ítem Poké Ball (`PokeballItemEffect`)

- Nuevo `PokeballItemEffect` como `ItemEffect` reutilizable (sin duplicar lógica de ítems).
- Validación de uso: solo **combate salvaje**, objetivo capturable.
- Parámetros: `capture_ball_modifier`, `guaranteed_capture` (Master Ball).
- Efectos asignados en `.tres`: Poké Ball, Super Ball, Ultra Ball, Master Ball.
- `BattlePokeballItemCategory` → `BattlePokeballItemHandler` como orquestador en combate.

### [AB#331](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/331) — Lógica de captura y secuencia visual (`CaptureEffect`)

- `CaptureResult` tipado (éxito, sacudidas, fallo temprano, Pokémon capturado, etc.).
- `CaptureEffect` con fórmula de captura **Gen VI** (umbral de sacudida corregido respecto a la fórmula Gen III errónea).
- Hasta **3 sacudidas visibles** + **4.º check** solo para decidir captura.
- Secuencia de mensajes al estilo clásico:
  - Uso de ball por el **entrenador** (no el Pokémon).
  - Fallos según sacudidas (0–3) en **un solo cuadro de texto** (dos líneas con salto de línea).
  - Éxito: «¡Ya está!» / «¡{nombre} atrapado!».
- Sacudidas registradas en **consola** (debug) mientras no hay animación dedicada.
- Clonado del salvaje a `Pokemon` con metadatos de captura (OT, fecha, ruta, nivel de captura).

### [AB#326](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/326) — Mochila en combate y flujo de Poké Ball

- Uso de bolas desde la mochila de combate (`BattleBagChoice` + `BagUI` / `BagController`).
- Bloqueo de captura en combates contra entrenador.
- Selección de objetivo enemigo para Poké Ball (`enemies_only` en selector).
- Sin mensaje genérico «Se usó el objeto…» al lanzar ball (solo el mensaje de captura).
- **Memoria de último bolsillo** de la mochila entre aperturas (misma sesión).

### [AB#327](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/327) — Registro del Pokémon capturado (`CaptureRegistrationService`)

- Alta automática al finalizar combate: **equipo** → **PC** (`send_to_pc`) → cola **`pending_pc_pokemon`** si el PC no está disponible.
- Persistencia de `pending_pc_pokemon` en **guardado/carga** (`GameStateService`).
- `BattleController`: registro de captura exitosa, fin de combate por captura y limpieza visual del salvaje **después** de la animación/mensajes.

---

## Mejoras relacionadas (mismo branch)

### Selección de objetivo en combates dobles

- Target `SELECCIONAR`: candidatos = todos excepto el usuario.
- Navegación con rejilla (`TargetSelectionGrid` + refactor de `BattleTargetSelectorUI`).
- `MovesMenu` visible durante la selección manual de objetivo.

### Efectividad de tipos en combate

- `TypeEffectivenessUtils`: combina efectividad del atacante y del defensor (`outgoing × incoming`).
- `TypeData.get_effectiveness_against_pokemon` unificado con la misma utilidad.
- Normal: `no_effect_to` Fantasma en datos (`01.tres`).
- Corrige casos como Placaje (Normal) vs Gastly (Fantasma/Veneno).

### TestBattle

- Combate fijo opcional Rattata vs Gastly salvaje.
- Semilla de bolas y **Poción** en mochila para pruebas.