### PR TITLE
PBI AB#424 - Separar orden de aplicación y visualización de efectos persistentes

### DIFF
--- a/Resources/Data/Abilities/022-INTIMIDATE.tres
+++ b/Resources/Data/Abilities/022-INTIMIDATE.tres
@@ -1,6 +1,7 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=2 format=3 uid="uid://ddhhye5l5wyr3"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=3 format=3 uid="uid://ddhhye5l5wyr3"]
 
 [ext_resource type="Script" uid="uid://poe0b2kpocvg" path="res://Scripts/Resources/Classes/AbilityData.gd" id="1_ability"]
+[ext_resource type="Script" uid="uid://b2tjovb8drlwf" path="res://Scripts/Battle/core/Battle Effects/Persistent/Abilities/IntimidateAbilityEffect.gd" id="2_effect"]
 
 [resource]
 script = ExtResource("1_ability")
@@ -8,3 +9,4 @@ id = 22
 internal_name = "intimidate"
 display_name = "Intimidación"
 description = "Reduce el Ataque del rival al entrar en combate."
+effect_resource = ExtResource("2_effect")

--- a/Scenes/Battle/TestBattle.tscn
+++ b/Scenes/Battle/TestBattle.tscn
@@ -1,19 +1,20 @@
-[gd_scene load_steps=5 format=3 uid="uid://clrnq0wq7bjw7"]
+[gd_scene format=3 uid="uid://clrnq0wq7bjw7"]
 
 [ext_resource type="Script" uid="uid://dfsjekxx61vm7" path="res://Scripts/Battle/TestBattle.gd" id="1_tse6d"]
 [ext_resource type="PackedScene" uid="uid://c22wi0px6h3ic" path="res://Scenes/Overworld/Core/Battler.tscn" id="2_rfkpo"]
 [ext_resource type="Script" uid="uid://ct0qiycflsnlt" path="res://Scripts/Battler.gd" id="3_bfl41"]
 
-[node name="TestBattle" type="Node2D"]
+[node name="TestBattle" type="Node2D" unique_id=764670732]
 script = ExtResource("1_tse6d")
+debug_seed_persistent_effects = true
 
-[node name="Player" type="Node" parent="."]
+[node name="Player" type="Node" parent="." unique_id=1369444140]
 script = ExtResource("3_bfl41")
 is_player = true
 
-[node name="SingleTrainer" parent="." instance=ExtResource("2_rfkpo")]
+[node name="SingleTrainer" parent="." unique_id=493080123 instance=ExtResource("2_rfkpo")]
 
-[node name="WildPokemons" type="Node" parent="."]
+[node name="WildPokemons" type="Node" parent="." unique_id=692555212]
 script = ExtResource("3_bfl41")
 
 [editable path="SingleTrainer"]

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -3,8 +3,13 @@ extends Node2D
 const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 
 @export_group("Equipos de prueba")
-## Si true, lanza un 1vs1 salvaje fijo: Rattata Nv.20 (jugador) vs Gastly Nv.20 (rival).
+## Si true, lanza un 1vs1 salvaje fijo: Growlithe (Intimidación) + Ekans en banca vs Gastly Nv.20.
 @export var use_fixed_rattata_vs_gastly: bool = true
+
+@export_group("Debug efectos persistentes")
+## Al iniciar combate: lluvia activa, Reflejo en el lado del jugador y veneno en el primer activo.
+## Sirve para probar el orden de mensajes al final del turno (Reflejo → Lluvia → Veneno).
+@export var debug_seed_persistent_effects: bool = false
 ## Tamaño del party del jugador (1–6). En doble solo 2 salen al campo; el resto queda en banca para cambios.
 @export_range(1, 6) var test_player_party_size: int = 6
 ## Tamaño del party del entrenador rival (1–6) cuando se use singleTrainerBattle / trainers en escena.
@@ -32,7 +37,7 @@ func _ready() -> void:
 		_setup_test_battler_parties()
 	_seed_test_capture_items()
 	if use_fixed_rattata_vs_gastly:
-		print(">>> Combate fijo: Rattata Nv.20 vs Gastly salvaje Nv.20")
+		print(">>> Combate fijo: Growlithe (Intimidación) + Ekans (Intimidación) vs Gastly Nv.20")
 		await wildFixedRattataGastlyBattle()
 		return
 	# Lanzar combates en bucle para testing continuo
@@ -85,7 +90,7 @@ func wildSingleBattle():
 
 	var participants:Array[BattleParticipant] = [playerParticipant, wildParticipant]
 
-	var winner = await DisplayManager.start_battle(participants, rules)
+	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
 
@@ -111,19 +116,18 @@ func wildDoubleBattle():
 
 	var participants:Array[BattleParticipant] = [playerParticipant, wildParticipant]
 
-	var winner = await DisplayManager.start_battle(participants, rules)
+	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
 func wildFixedRattataGastlyBattle() -> void:
-	var player_participant: BattleParticipant = _create_fixed_player_participant(
-		PokemonsEnum.Values.RATTATA, 20
-	)
+	var player_participant: BattleParticipant = _create_fixed_player_participant()
 	var wild_participant: BattleParticipant = _create_fixed_wild_participant(
 		PokemonsEnum.Values.GASTLY, 20
 	)
 	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.SINGLE)
-	var winner = await DisplayManager.start_battle([player_participant, wild_participant], rules)
-	print(">>> Batalla Rattata vs Gastly terminada. Ganador: %s" % winner)
+	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla Growlithe/Ekans vs Gastly terminada. Ganador: %s" % winner)
 
 
 func wildRandomSingleBattle():
@@ -138,7 +142,7 @@ func wildRandomSingleBattle():
 
 	var participants:Array[BattleParticipant] = [playerParticipant, wildParticipant]
 
-	var winner = await DisplayManager.start_battle(participants, rules)
+	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
 func wildRandomDoubleBattle():
@@ -153,7 +157,7 @@ func wildRandomDoubleBattle():
 
 	var participants:Array[BattleParticipant] = [playerParticipant, wildParticipant]
 
-	var winner = await DisplayManager.start_battle(participants, rules)
+	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
 
 func singleTrainerBattle():
@@ -168,17 +172,30 @@ func singleTrainerBattle():
 
 	var participants:Array[BattleParticipant] = [playerParticipant, trainerParticipant]
 
-	var winner = await DisplayManager.start_battle(participants, rules)
+	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
+
+
+func _start_test_battle(participants: Array[BattleParticipant], rules: BattleRules) -> String:
+	if debug_seed_persistent_effects:
+		BattleDebugEffectSeeder.enable()
+	return await DisplayManager.start_battle(participants, rules)
+
 
 ## Party en escena para `player` / `wildPokemons` (combate fijo por battler opcional).
 func _setup_fixed_rattata_gastly_parties() -> void:
 	if player != null:
 		player.party.clear()
+		player.add_pokemon_to_party(
+			_create_pokemon_instance(PokemonsEnum.Values.GROWLITHE, 20, false, AbilitiesEnum.Values.INTIMIDATE)
+		)
+		player.add_pokemon_to_party(
+			_create_pokemon_instance(PokemonsEnum.Values.EKANS, 20, false, AbilitiesEnum.Values.INTIMIDATE)
+		)
 		player.add_pokemon_to_party(_create_pokemon_instance(PokemonsEnum.Values.RATTATA, 20, false))
 	if wildPokemons != null:
 		wildPokemons.party.clear()
-		wildPokemons.add_pokemon_to_party(_create_pokemon_instance(PokemonsEnum.Values.GASTLY, 100, true))
+		wildPokemons.add_pokemon_to_party(_create_pokemon_instance(PokemonsEnum.Values.GASTLY, 20, true))
 
 
 ## Rellena los Battler de escena para pruebas con party configurado en inspector.
@@ -219,15 +236,26 @@ func _seed_test_capture_items() -> void:
 	print("TestBattle: ítems de prueba en mochila (bolas x10, Poción x10).")
 
 
-func _create_pokemon_instance(species_id: int, level: int, is_wild: bool) -> Pokemon:
-	var pokemon_data = DatabaseService.get_pokemon(species_id)
-	var pkmn := Pokemon.new(pokemon_data, level, 0, 0, 0, true)
+func _create_pokemon_instance(
+	species_id: int, level: int, is_wild: bool, forced_ability = null
+) -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = species_id as PokemonsEnum.Values
+	pkmn.level = level
 	pkmn.is_wild = is_wild
+	if forced_ability != null:
+		pkmn.ability_id = int(forced_ability) as AbilitiesEnum.Values
+	pkmn._post_init()
 	return pkmn
 
 
-func _create_fixed_player_participant(species_id: int, level: int) -> BattleParticipant:
-	var team: Array[BattlePokemon] = [_create_pokemon_instance(species_id, level, false).to_battle_pokemon()]
+func _create_fixed_player_participant() -> BattleParticipant:
+	var team: Array[BattlePokemon] = []
+	if player == null or player.party.is_empty():
+		push_error("TestBattle: el Battler Player no tiene party configurado.")
+		return BattleParticipant.new(team)
+	for p: Pokemon in player.party:
+		team.append(p.to_battle_pokemon())
 	var participant := BattleParticipant.new(team)
 	participant.is_player = true
 	participant.name = "Jugador"

--- a/Scripts/Battle/core/Battle Effects/BattleEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/BattleEffect.gd
@@ -2,7 +2,7 @@ class_name BattleEffect
 extends RefCounted
 
 enum Phases {
-	ON_ENTRY,
+	ON_BATTLE_START,
 	ON_INIT_BATTLE_TURN,
 	ON_INIT_POKEMON_TURN,
 	ON_BEFORE_MOVE,

--- a/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
@@ -8,29 +8,29 @@ var in_pokemon: BattlePokemon
 var rules: BattleRules
 
 func _init(_side: BattleSide, _spot: BattleSpot, _out: BattlePokemon, _in: BattlePokemon, _rules: BattleRules):
-    side = _side
-    spot = _spot
-    out_pokemon = _out
-    in_pokemon = _in
-    rules = _rules
+	side = _side
+	spot = _spot
+	out_pokemon = _out
+	in_pokemon = _in
+	rules = _rules
 
 func apply():
-    if out_pokemon:
-        # Al salir del campo, sus efectos persistentes de combate dejan de estar activos.
-        var effects_ctrl := BattleEffectController.get_instance()
-        if effects_ctrl != null:
-            effects_ctrl._clear_pokemon_effects(out_pokemon)
-        out_pokemon.in_battle = false
-    if spot and in_pokemon:
-        spot.load_active_pokemon(in_pokemon, rules)
+	if out_pokemon:
+		# Al salir del campo, sus efectos persistentes de combate dejan de estar activos.
+		var effects_ctrl := BattleEffectController.get_instance()
+		if effects_ctrl != null:
+			effects_ctrl._clear_pokemon_effects(out_pokemon)
+		out_pokemon.in_battle = false
+	if spot and in_pokemon:
+		spot.load_active_pokemon(in_pokemon, rules)
 
 func visualize(ui):
-    # Muestra mensaje y animación de switch
-    var out_name = out_pokemon.get_name() if out_pokemon else "(ninguno)"
-    var in_name = in_pokemon.get_name() if in_pokemon else "(ninguno)"
+	var out_name = out_pokemon.get_name() if out_pokemon else "(ninguno)"
+	var in_name = in_pokemon.get_name() if in_pokemon else "(ninguno)"
 
-    await ui.show_switch_message(side.to_string(), in_name)
+	await ui.show_switch_message(side.to_string(), in_name)
+	print("[SWITCH] Sale %s, entra %s" % [out_name, in_name])
 
-    # Log de debug (opcional)
-    print("[SWITCH] Sale %s, entra %s" % [out_name, in_name])
+	if in_pokemon != null and not in_pokemon.is_fainted():
+		await BattleEffectController.process_phase(in_pokemon, BattleEffect.Phases.ON_SWITCH_IN)
 

--- a/Scripts/Battle/core/Battle Effects/Persistent/Abilities/IntimidateAbilityEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Abilities/IntimidateAbilityEffect.gd
@@ -1,23 +1,23 @@
 extends PersistentBattleEffect
 class_name IntimidateAbilityEffect
 
-func apply_phase(pokemon:BattlePokemon, phase: Phases) -> void: 
-	if phase != Phases.ON_ENTRY:
-		return 
+func _is_entry_phase(phase: Phases) -> bool:
+	return phase == Phases.ON_BATTLE_START or phase == Phases.ON_SWITCH_IN
 
-	# Aplica -1 ataque a cada enemigo activo
+func apply_phase(pokemon: BattlePokemon, phase: Phases) -> void:
+	if not _is_entry_phase(phase):
+		return
 	var enemies := pokemon.side.opponent_side.get_active_pokemons()
-	for target:BattlePokemon in enemies:
+	for target: BattlePokemon in enemies:
 		target.stat_stages.decrease(StatsEnum.Values.ATTACK, 1)
 
-func visualize_phase(pokemon:BattlePokemon, ui: BattleUI, phase: Phases) -> void:
-	if phase != Phases.ON_ENTRY:
+func visualize_phase(pokemon: BattlePokemon, ui: BattleUI, phase: Phases) -> void:
+	if not _is_entry_phase(phase):
 		return
-
 	var enemies := pokemon.side.opponent_side.get_active_pokemons()
-	for target:BattlePokemon in enemies:
-		#await ui.messagebox.show_message("¡La Intimidación de %s afecta a %s!" % [source.get_name(), target.get_name()])
-		await ui.show_ability_effect_message(pokemon, target, source)
-	
+	var ability_id: int = source.id if source is AbilityData else int(source)
+	for target: BattlePokemon in enemies:
+		await ui.show_ability_effect_message(pokemon, target, ability_id)
+
 func get_priority() -> int:
 	return 10

--- a/Scripts/Battle/core/Battle Effects/Persistent/Field/ReflectFieldEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Field/ReflectFieldEffect.gd
@@ -16,7 +16,7 @@ func apply_phase(_pokemon, phase: Phases) -> void:
 		next_turn()
 
 func visualize_phase(_pokemon, ui: BattleUI, phase: Phases) -> void:
-	if phase == Phases.ON_ENTRY:
+	if phase == Phases.ON_BATTLE_START:
 		await ui.show_start_effect_message(MessageFamily.Values.FIELD_EFFECT, source.pokemon, source.get_id())
 	elif phase == Phases.ON_END_BATTLE_TURN and has_finished():
 		await ui.show_end_effect_message(MessageFamily.Values.FIELD_EFFECT, source.pokemon, source.get_id())

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/RainWeatherEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/RainWeatherEffect.gd
@@ -14,7 +14,7 @@ func apply_phase(_pokemon: BattlePokemon, phase: Phases) -> void:
 		# No eliminamos aquí: el BattleEffectController lo hace después de visualize_phase()
 
 func visualize_phase(_pokemon: BattlePokemon, ui: BattleUI, phase: Phases) -> void:
-	if phase == Phases.ON_ENTRY:
+	if phase == Phases.ON_BATTLE_START:
 		await ui.show_message_from_dict(ui.message_controller.get_start_weather_message(source.id))
 	elif phase == Phases.ON_END_BATTLE_TURN:
 		if has_finished():

--- a/Scripts/Battle/core/Battle Effects/PersistentBattleEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/PersistentBattleEffect.gd
@@ -1,7 +1,10 @@
 class_name PersistentBattleEffect
 extends BattleEffect
 
+enum EffectSource { WEATHER, FIELD, AILMENT, ABILITY, ITEM, OTHER }
+
 var source # AilmentData/AbilityData/WeatherData
+var effect_source: EffectSource = EffectSource.OTHER
 var effect_success:bool
 var turns_left:int
 var applied:bool = false
@@ -10,6 +13,48 @@ func _init(_source, _min_turns = null, _max_turns = null) -> void:
 	source = _source
 	if _min_turns and _max_turns:
 		turns_left = randi_range(_min_turns, _max_turns)
+
+## Llamar solo desde BattleEffectController al registrar el efecto (instancia ya construida).
+func detect_effect_source() -> void:
+	effect_source = classify_from_class_name(_resolve_effect_class_name())
+	if effect_source == EffectSource.OTHER:
+		push_warning(
+			"PersistentBattleEffect: no se pudo clasificar '%s' (effect_source=OTHER)."
+			% _resolve_effect_class_name()
+		)
+
+static func classify_from_class_name(class_name_lower: String) -> EffectSource:
+	if class_name_lower.contains("weather"):
+		return EffectSource.WEATHER
+	if class_name_lower.contains("field") or class_name_lower.contains("side"):
+		return EffectSource.FIELD
+	if class_name_lower.contains("ailment") or class_name_lower.contains("status"):
+		return EffectSource.AILMENT
+	if class_name_lower.contains("ability"):
+		return EffectSource.ABILITY
+	if class_name_lower.contains("item"):
+		return EffectSource.ITEM
+	return EffectSource.OTHER
+
+func _resolve_effect_class_name() -> String:
+	var script: Script = get_script()
+	if script != null:
+		var global_name: String = script.get_global_name()
+		if not global_name.is_empty():
+			return global_name.to_lower()
+		var file_name: String = script.resource_path.get_file().get_basename()
+		if not file_name.is_empty():
+			return file_name.to_lower()
+	return get_class().to_lower()
+
+static func get_visual_order(src: EffectSource) -> int:
+	match src:
+		EffectSource.FIELD: return 0
+		EffectSource.WEATHER: return 1
+		EffectSource.AILMENT: return 2
+		EffectSource.ABILITY: return 3
+		EffectSource.ITEM: return 4
+		_: return 5
 
 func apply_phase(_pokemon, _phase: Phases) -> void: return
 func visualize_phase(_pokemon, _ui, _phase: Phases) -> void: return

--- a/Scripts/Battle/core/Controllers/BattleController.gd
+++ b/Scripts/Battle/core/Controllers/BattleController.gd
@@ -110,6 +110,7 @@ func _on_battle_spot_active_pokemon_loaded(bp: BattlePokemon) -> void:
 func start_battle() -> void:
 	# Configurar UI para el nuevo combate
 	BattleEffectController.set_ui(ui)
+	BattleDebugEffectSeeder.try_apply(self)
 
 	turn_controller.battle_controller = self
 	# Inyectar lógica de targeting en la UI

--- a/Scripts/Battle/core/Controllers/BattleEffectController.gd
+++ b/Scripts/Battle/core/Controllers/BattleEffectController.gd
@@ -4,9 +4,6 @@ extends Node
 # 🔁 Singleton interno
 static var _instance: BattleEffectController
 
-func _ready():
-	_instance = self
-
 static func get_instance() -> BattleEffectController:
 	if _instance == null:
 		push_warning("BattleEffectController.get_instance() llamado antes de inicializarse.")
@@ -45,6 +42,12 @@ static func has_side_effect(side: String, effect_instance: PersistentBattleEffec
 
 static func get_all_effects_for(pokemon):
 	return get_instance()._get_all_effects_for(pokemon)
+
+static func get_all_effects_to_apply_for(pokemon) -> Array[PersistentBattleEffect]:
+	return get_instance()._get_all_effects_to_apply_for(pokemon)
+
+static func get_all_effects_to_visualize_for(pokemon) -> Array[PersistentBattleEffect]:
+	return get_instance()._get_all_effects_to_visualize_for(pokemon)
 
 static func get_pokemon_effects(pokemon):
 	return get_instance()._get_pokemon_effects(pokemon)
@@ -92,24 +95,54 @@ static func reset_effects():
 		instance.pokemon_effects.clear()
 		instance.field_effects.clear()
 		instance.side_effects.clear()
+		instance._ensure_side_effect_list("Player")
+		instance._ensure_side_effect_list("Enemy")
 
 # 🔐 Datos internos
-var pokemon_effects: Dictionary = {}
+var pokemon_effects: Dictionary = {}  # BattlePokemon -> Array[PersistentBattleEffect]
 var field_effects: Array[PersistentBattleEffect] = []
-var side_effects: Dictionary = { "Player": [], "Enemy": [] }
+var side_effects: Dictionary = {}  # String -> Array[PersistentBattleEffect]
 var ui: BattleUI
 
+func _ready():
+	_instance = self
+	_ensure_side_effect_list("Player")
+	_ensure_side_effect_list("Enemy")
+
+func _empty_effect_list() -> Array[PersistentBattleEffect]:
+	var list: Array[PersistentBattleEffect] = []
+	return list
+
+func _ensure_side_effect_list(side: String) -> Array[PersistentBattleEffect]:
+	if not side_effects.has(side):
+		side_effects[side] = _empty_effect_list()
+	return side_effects[side]
+
+func _filter_out_effect_class(
+	effects: Array[PersistentBattleEffect], target_class: String
+) -> Array[PersistentBattleEffect]:
+	var kept := _empty_effect_list()
+	for e in effects:
+		if e.get_script().get_global_name() != target_class:
+			kept.append(e)
+	return kept
+
 # 🔧 Métodos internos
+func _register_effect(effect: PersistentBattleEffect) -> void:
+	if effect != null:
+		effect.detect_effect_source()
+
 func _add_pokemon_effect(pokemon, effect: PersistentBattleEffect):
+	_register_effect(effect)
 	if not pokemon_effects.has(pokemon):
-		pokemon_effects[pokemon] = []
+		pokemon_effects[pokemon] = _empty_effect_list()
 	pokemon_effects[pokemon].append(effect)
 
 func _remove_pokemon_effect(pokemon, effect: PersistentBattleEffect):
 	if not pokemon_effects.has(pokemon):
 		return
 	var target_class = effect.get_script().get_global_name()
-	pokemon_effects[pokemon] = pokemon_effects[pokemon].filter(func(e): return e.get_script().get_global_name() != target_class)
+	pokemon_effects[pokemon] = _filter_out_effect_class(pokemon_effects[pokemon], target_class)
 	if pokemon_effects[pokemon].is_empty():
 		pokemon_effects.erase(pokemon)
 
@@ -120,24 +153,24 @@ func _clear_pokemon_effects(pokemon) -> void:
 		pokemon_effects.erase(pokemon)
 
 func _add_side_effect(side: String, effect: PersistentBattleEffect):
-	if not side_effects.has(side):
-		side_effects[side] = []
-	side_effects[side].append(effect)
+	_register_effect(effect)
+	_ensure_side_effect_list(side).append(effect)
 
 func _remove_side_effect(side: String, effect: PersistentBattleEffect):
 	if not side_effects.has(side):
 		return
 	var target_class = effect.get_script().get_global_name()
-	side_effects[side] = side_effects[side].filter(func(e): return e.get_script().get_global_name() != target_class)
+	side_effects[side] = _filter_out_effect_class(side_effects[side], target_class)
 	if side_effects[side].is_empty():
 		side_effects.erase(side)
 
 func _add_field_effect(effect: PersistentBattleEffect):
+	_register_effect(effect)
 	field_effects.append(effect)
 
 func _remove_field_effect(effect: PersistentBattleEffect):
 	var target_class = effect.get_script().get_global_name()
-	field_effects = field_effects.filter(func(e): return e.get_script().get_global_name() != target_class)
+	field_effects = _filter_out_effect_class(field_effects, target_class)
 
 func _has_effect_for(pokemon, effect: PersistentBattleEffect) -> bool:
 	var target_class = effect.get_script().get_global_name()
@@ -155,23 +188,46 @@ func _has_side_effect(side: String, effect: PersistentBattleEffect) -> bool:
 	return side_effects[side].any(func(e): return e.get_script().get_global_name() == target_class)
 
 func _get_all_effects_for(pokemon) -> Array[PersistentBattleEffect]:
+	return _get_all_effects_to_apply_for(pokemon)
+
+func _get_all_effects_to_apply_for(pokemon) -> Array[PersistentBattleEffect]:
 	var result: Array[PersistentBattleEffect] = []
 	result.append_array(_get_pokemon_effects(pokemon))
 	result.append_array(_get_side_effects(pokemon))
 	result.append_array(_get_field_effects())
-	result.sort_custom(func(a, b): return b.get_priority() - a.get_priority())
-	return result
+	return _sort_effects_for_apply(result)
 
-func _get_pokemon_effects(pokemon):
+func _get_all_effects_to_visualize_for(pokemon) -> Array[PersistentBattleEffect]:
+	var result: Array[PersistentBattleEffect] = []
+	result.append_array(_get_pokemon_effects(pokemon))
+	result.append_array(_get_side_effects(pokemon))
+	result.append_array(_get_field_effects())
+	return _sort_effects_for_visualize(result)
+
+static func _sort_effects_for_apply(effects: Array[PersistentBattleEffect]) -> Array[PersistentBattleEffect]:
+	var sorted := effects.duplicate()
+	sorted.sort_custom(func(a, b): return a.effect_source < b.effect_source)
+	return sorted
+
+static func _sort_effects_for_visualize(effects: Array[PersistentBattleEffect]) -> Array[PersistentBattleEffect]:
+	var sorted := effects.duplicate()
+	sorted.sort_custom(func(a, b): return PersistentBattleEffect.get_visual_order(a.effect_source) < PersistentBattleEffect.get_visual_order(b.effect_source))
+	return sorted
+
+func _get_pokemon_effects(pokemon) -> Array[PersistentBattleEffect]:
 	if pokemon_effects.has(pokemon):
-		return pokemon_effects[pokemon].duplicate()
-	return []
+		var list: Array[PersistentBattleEffect] = pokemon_effects[pokemon]
+		return list.duplicate()
+	return _empty_effect_list()
 
-func _get_side_effects(pokemon:BattlePokemon):
-	var side = pokemon.side.to_string()
+func _get_side_effects(pokemon: BattlePokemon) -> Array[PersistentBattleEffect]:
+	if pokemon == null or pokemon.side == null:
+		return _empty_effect_list()
+	var side := pokemon.side.to_string()
 	if side_effects.has(side):
-		return side_effects[side].duplicate()
-	return []
+		var list: Array[PersistentBattleEffect] = side_effects[side]
+		return list.duplicate()
+	return _empty_effect_list()
 
 func _get_field_effects() -> Array[PersistentBattleEffect]:
 	return field_effects.duplicate()
@@ -190,53 +246,69 @@ func _process_phase(pokemon: BattlePokemon, phase: BattleEffect.Phases):
 	await visualize_phase(pokemon, phase)
 
 func _process_global_phase(phase: BattleEffect.Phases):
-	for effect in field_effects:
+	var global_effects: Array[PersistentBattleEffect] = []
+	global_effects.append_array(field_effects)
+	for side_key in side_effects.keys():
+		global_effects.append_array(side_effects[side_key])
+	global_effects = _sort_effects_for_apply(global_effects)
+	for effect in global_effects:
 		effect.apply_phase(null, phase)
-	for effect in field_effects:
+	for effect in _sort_effects_for_visualize(global_effects):
 		await effect.visualize_phase(null, ui, phase)
-		if effect.has_finished(): remove_field_effect(effect)
-	for side in side_effects.keys():
-		for effect in side_effects[side]:
-			effect.apply_phase(null, phase)
-		for effect in side_effects[side]:
-			await effect.visualize_phase(null, ui, phase)
-			if effect.has_finished(): remove_side_effect(side, effect)
-	# Efectos persistentes ligados a Pokémon (veneno/quemadura/etc.) en fase global de fin de turno.
+		_remove_global_effect_if_finished(effect)
 	for bp in pokemon_effects.keys():
 		var pokemon: BattlePokemon = bp as BattlePokemon
 		if pokemon == null:
 			continue
-		for effect in _get_pokemon_effects(pokemon):
+		for effect in _sort_effects_for_apply(_get_pokemon_effects(pokemon)):
 			effect.apply_phase(pokemon, phase)
-		for effect in _get_pokemon_effects(pokemon):
+		for effect in _sort_effects_for_visualize(_get_pokemon_effects(pokemon)):
 			await effect.visualize_phase(pokemon, ui, phase)
 			if effect.has_finished():
 				remove_pokemon_effect(pokemon, effect)
 
 func _apply_phase(pokemon, phase):
-	for effect in _get_all_effects_for(pokemon):
+	for effect in _get_all_effects_to_apply_for(pokemon):
 		effect.apply_phase(pokemon, phase)
 
 func _visualize_phase(pokemon, phase):
-	for effect in _get_all_effects_for(pokemon):
+	for effect in _get_all_effects_to_visualize_for(pokemon):
 		await effect.visualize_phase(pokemon, ui, phase)
-		if effect.has_finished(): remove_pokemon_effect(pokemon, effect)
+		if effect.has_finished():
+			_remove_pokemon_scoped_effect(pokemon, effect)
 
+func _remove_global_effect_if_finished(effect: PersistentBattleEffect) -> void:
+	if not effect.has_finished():
+		return
+	if field_effects.any(func(e): return e == effect):
+		remove_field_effect(effect)
+		return
+	for side_key in side_effects.keys():
+		if side_effects[side_key].any(func(e): return e == effect):
+			remove_side_effect(side_key, effect)
+			return
+
+func _remove_pokemon_scoped_effect(pokemon, effect: PersistentBattleEffect) -> void:
+	if _get_pokemon_effects(pokemon).any(func(e): return e == effect):
+		remove_pokemon_effect(pokemon, effect)
+	elif _get_side_effects(pokemon).any(func(e): return e == effect):
+		remove_side_effect(pokemon.side.to_string(), effect)
+	elif field_effects.any(func(e): return e == effect):
+		remove_field_effect(effect)
 
 func _apply_global_phase(phase: BattleEffect.Phases) -> void:
-	for effect in field_effects:
+	var global_effects: Array[PersistentBattleEffect] = []
+	global_effects.append_array(field_effects)
+	for side_key in side_effects.keys():
+		global_effects.append_array(side_effects[side_key])
+	for effect in _sort_effects_for_apply(global_effects):
 		await effect.apply_phase(null, phase)
 
-	for side in side_effects.keys():
-		for effect in side_effects[side]:
-			# Nota: puedes pasar el "lado" como string si lo necesita
-			await effect.apply_phase(null, phase)
-
 func _visualize_global_phase(phase: BattleEffect.Phases) -> void:
-	for effect in field_effects:
+	var global_effects: Array[PersistentBattleEffect] = []
+	global_effects.append_array(field_effects)
+	for side_key in side_effects.keys():
+		global_effects.append_array(side_effects[side_key])
+	for effect in _sort_effects_for_visualize(global_effects):
 		await effect.visualize_phase(null, ui, phase)
-		if effect.has_finished(): remove_field_effect(effect)
-	for side in side_effects.keys():
-		for effect in side_effects[side]:
-			await effect.visualize_phase(null, ui, phase)
-			if effect.has_finished(): remove_side_effect(side, effect)
+		_remove_global_effect_if_finished(effect)

--- a/Scripts/Battle/core/Controllers/BattleTurnController.gd
+++ b/Scripts/Battle/core/Controllers/BattleTurnController.gd
@@ -14,8 +14,7 @@ func _ready():
 	randomize()
 
 func start_turn_loop():
-	for pokemon in battle_controller.get_all_active_pokemon():
-		await BattleEffectController.process_phase(pokemon, BattleEffect.Phases.ON_ENTRY)
+	await BattleEffectController.process_global_phase(BattleEffect.Phases.ON_BATTLE_START)
 	while not battle_controller.battle_finished():
 		await new_turn()
 		await select_actions()
@@ -26,8 +25,8 @@ func start_turn_loop():
 
 func new_turn():
 	current_turn += 1
-	#battle_controller.new_turn.emit()
-	#battle_ui.actions_menu.hide()  # o mostrar algo específico si lo necesitas
+	if not battle_controller.finished:
+		await BattleEffectController.process_global_phase(BattleEffect.Phases.ON_INIT_BATTLE_TURN)
 
 func select_actions():
 	collected_choices.clear()
@@ -90,24 +89,24 @@ func execute_turn():
 
 	print_turn_debug_log(ordered_choices, results)
 
-	# Mostrar animaciones y efectos tras resolver todo
+	# Mostrar animaciones y efectos tras resolver todo (orden de velocidad)
 	for choice in ordered_choices:
-		if results.has(choice):
-			var actor: BattlePokemon = choice.pokemon
-			# El rival puede haber caído antes de su turno (más rápido que él): no ejecutar ni revisar KO con actor nulo.
-			if actor != null and not actor.is_fainted():
-				await handle_result(choice, results[choice])
+		if not results.has(choice):
+			continue
+		var actor: BattlePokemon = choice.pokemon
+		# El rival puede haber caído antes de su turno (más rápido que él): no ejecutar ni revisar KO con actor nulo.
+		if actor == null or actor.is_fainted():
+			continue
 
-			if actor != null:
-				await check_and_show_fainted_pokemon(actor)
+		await BattleEffectController.process_phase(actor, BattleEffect.Phases.ON_INIT_POKEMON_TURN)
+		await handle_result(choice, results[choice])
 
-			# Verificar si el combate ha terminado después de cada acción
-			if battle_controller.battle_finished():
-				break
+		await check_and_show_fainted_pokemon(actor)
 
-	# Aplicar efectos de fin de turno solo si el combate no ha terminado
-	if not battle_controller.finished:
-		await BattleEffectController.process_global_phase(BattleEffect.Phases.ON_END_BATTLE_TURN)
+		if battle_controller.battle_finished():
+			break
+		else:
+			await BattleEffectController.process_phase(actor, BattleEffect.Phases.ON_END_POKEMON_TURN)
 
 func order_choices(battle_choices: Array[BattleChoice]) -> Array[BattleChoice]:
 	battle_choices.sort_custom(_sort_choices)
@@ -197,11 +196,9 @@ func handle_move_result(choice: BattleMoveChoice, handlers: Array[BattleHandler]
 		await h.visualize(battle_controller.ui)
 
 func handle_switch_result(_choice: BattleSwitchChoice, handlers: Array[BattleHandler]) -> void:
-	# Aplicar todos los handlers
 	for handler in handlers:
 		handler.apply()
 
-	# Visualizar todos los handlers
 	for handler in handlers:
 		await handler.visualize(battle_controller.ui)
 
@@ -224,9 +221,9 @@ func handle_run_result(choice: BattleRunChoice, handlers: Array[BattleHandler]) 
 		await handler.visualize(battle_controller.ui)
 
 func end_turn():
+	if not battle_controller.finished:
+		await BattleEffectController.process_global_phase(BattleEffect.Phases.ON_END_BATTLE_TURN)
 	turn_finished.emit(current_turn)
-	# Aquí iría lógica futura de efectos, clima, estados...
-	#await battle_controller.end_turn()
 
 func reset():
 	# Limpiar estado del controlador de turnos para el siguiente combate

--- a/Scripts/Battle/debug/BattleDebugEffectSeeder.gd
+++ b/Scripts/Battle/debug/BattleDebugEffectSeeder.gd
@@ -1,0 +1,69 @@
+class_name BattleDebugEffectSeeder
+extends RefCounted
+
+## Activa lluvia (campo), Reflejo (lado jugador) y veneno (primer Pokémon activo del jugador)
+## Pensado para probar el orden de fin de turno en TestBattle.
+static var _pending: bool = false
+
+static func enable() -> void:
+	_pending = true
+
+static func try_apply(controller: BattleController) -> void:
+	if not _pending:
+		return
+	_pending = false
+	_apply(controller)
+
+static func _apply(controller: BattleController) -> void:
+	if controller == null or controller.player_side == null:
+		return
+	var player_team: Array = controller.player_side.get_active_pokemons()
+	if player_team.is_empty():
+		push_warning("BattleDebugEffectSeeder: no hay Pokémon activo del jugador.")
+		return
+	var player_pkmn: BattlePokemon = player_team[0] as BattlePokemon
+
+	_seed_rain()
+	_seed_reflect(player_pkmn)
+	_seed_poison(player_pkmn)
+
+	print(
+		"BattleDebugEffectSeeder: lluvia + Reflejo (Player) + veneno en %s. Fin de turno → visual: Reflejo → Lluvia → Veneno."
+		% player_pkmn.get_name()
+	)
+
+static func _seed_rain() -> void:
+	var weather: WeatherData = DatabaseService.get_weather("rain")
+	if weather == null:
+		push_warning("BattleDebugEffectSeeder: DatabaseService.get_weather('rain') devolvió null.")
+		return
+	var rain := weather.get_effect(5, true)
+	if rain == null:
+		return
+	if BattleEffectController.has_field_effect(rain):
+		return
+	BattleEffectController.add_field_effect(rain)
+
+static func _seed_reflect(player_pkmn: BattlePokemon) -> void:
+	var move_data: MoveData = DatabaseService.get_move(115)
+	if move_data == null:
+		push_warning("BattleDebugEffectSeeder: no se encontró el movimiento Reflejo (115).")
+		return
+	var battle_move := BattleMove.new(Move.new(move_data), player_pkmn)
+	var reflect := ReflectFieldEffect.new(battle_move, 5, "Player", "tu lado")
+	if BattleEffectController.has_side_effect("Player", reflect):
+		return
+	BattleEffectController.add_side_effect("Player", reflect)
+
+static func _seed_poison(player_pkmn: BattlePokemon) -> void:
+	var poison_data: AilmentData = AilmentData.from_major_status(CONST.STATUS.POISON)
+	if poison_data == null:
+		push_warning("BattleDebugEffectSeeder: no se encontró ailment de veneno.")
+		return
+	player_pkmn.set_status(poison_data)
+	var poison: PersistentBattleEffect = poison_data.get_effect()
+	if poison == null:
+		return
+	if not BattleEffectController.has_effect_for(player_pkmn, poison):
+		BattleEffectController.add_pokemon_effect(player_pkmn, poison)
+	player_pkmn.status_changed.emit()

--- a/Scripts/Battle/debug/BattleDebugEffectSeeder.gd.uid
+++ b/Scripts/Battle/debug/BattleDebugEffectSeeder.gd.uid
@@ -1,0 +1,1 @@
+uid://bt3y8rt63jw3

--- a/Scripts/Battle/ui/BattleSpotUI.gd
+++ b/Scripts/Battle/ui/BattleSpotUI.gd
@@ -50,7 +50,7 @@ func load_active_pokemon(_pokemon: BattlePokemon, rules: BattleRules) -> void:
 	# Mostrar el spot completo
 	self.visible = true
 	if _pokemon.ability and _pokemon.ability.effect_resource:
-		var effect = pokemon.ability.effect_resource.new(_pokemon.ability)
+		var effect = _pokemon.ability.effect_resource.new(_pokemon.ability)
 		BattleEffectController.add_pokemon_effect(_pokemon, effect)
 
 	_register_persistent_ailment_effect_if_needed(_pokemon)

--- a/Scripts/Runtime/Pokemon.gd
+++ b/Scripts/Runtime/Pokemon.gd
@@ -209,18 +209,7 @@ func _init(
 	else:
 		gender = pokemon_gender
 
-	# Configurar habilidad
-	if pokemon_ability == null:
-		# Mantener valor @export o calcular si es NONE
-		if ability_id == AbilitiesEnum.Values.NONE:
-			ability_id = _calculate_ability() as AbilitiesEnum.Values
-	elif pokemon_ability == 0:
-		ability_id = _calculate_ability() as AbilitiesEnum.Values
-	else:
-		ability_id = pokemon_ability as AbilitiesEnum.Values
-
-	if not Engine.is_editor_hint():
-		ability = DatabaseService.get_ability(ability_id)
+	_configure_ability(pokemon_ability)
 
 	# Configurar naturaleza
 	if pokemon_nature == null:
@@ -297,11 +286,7 @@ func _post_init() -> void:
 	if gender == 0:  # "Sin indicar"
 		gender = _calculate_gender()
 
-	if ability_id == AbilitiesEnum.Values.NONE:
-		ability_id = _calculate_ability() as AbilitiesEnum.Values
-
-	if not Engine.is_editor_hint():
-		ability = DatabaseService.get_ability(ability_id)
+	_configure_ability()
 
 	if not Engine.is_editor_hint():
 		nature = DatabaseService.get_nature(NaturesEnum.get_id(nature_id))
@@ -402,6 +387,37 @@ func _calculate_gender() -> int:
 			return CONST.GENEROS.HEMBRA
 		else:
 			return CONST.GENEROS.MACHO
+
+## Resuelve ability_id (forzado, @export o aleatorio por especie). No asigna AbilityData.
+func _resolve_ability_id(forced_ability: Variant = null) -> void:
+	if forced_ability != null:
+		if int(forced_ability) == 0:
+			ability_id = _calculate_ability() as AbilitiesEnum.Values
+		else:
+			ability_id = int(forced_ability) as AbilitiesEnum.Values
+	elif ability_id == AbilitiesEnum.Values.NONE:
+		ability_id = _calculate_ability() as AbilitiesEnum.Values
+
+
+## Único punto que asigna `ability` desde DatabaseService.
+func _apply_ability_from_database() -> void:
+	if ability_id == AbilitiesEnum.Values.NONE:
+		ability = null
+		return
+	if Engine.is_editor_hint() and base == null:
+		return
+	ability = DatabaseService.get_ability(int(ability_id))
+	if ability == null:
+		push_warning(
+			"Pokemon: no se encontró AbilityData para id %d (%s)"
+			% [int(ability_id), get_display_name() if base != null else "?"]
+		)
+
+
+func _configure_ability(forced_ability: Variant = null) -> void:
+	_resolve_ability_id(forced_ability)
+	_apply_ability_from_database()
+
 
 ## Calcula la habilidad aleatoria según las disponibles para la especie
 func _calculate_ability() -> int:
@@ -807,9 +823,7 @@ func apply_species_evolution(target_species_id: int) -> bool:
 	_refresh_base_stats_from_species()
 	_load_learnable_moves()
 
-	if not Engine.is_editor_hint():
-		ability_id = _calculate_ability() as AbilitiesEnum.Values
-		ability = DatabaseService.get_ability(ability_id)
+	_configure_ability()
 
 	var new_max_hp: int = get_final_stat(StatsEnum.Values.HP)
 	hp_actual = clampi(hp_actual + (new_max_hp - old_max_hp), 0, new_max_hp)

--- a/Scripts/Runtime/PokemonRuntimeSerde.gd
+++ b/Scripts/Runtime/PokemonRuntimeSerde.gd
@@ -47,8 +47,8 @@ func deserialize(data: Dictionary) -> Pokemon:
 	mon.capture_level = int(data.get("capture_level", mon.capture_level))
 	mon.personality = str(data.get("personality", mon.personality))
 
+	mon._apply_ability_from_database()
 	if not Engine.is_editor_hint():
-		mon.ability = DatabaseService.get_ability(mon.ability_id)
 		mon.nature = DatabaseService.get_nature(NaturesEnum.get_id(mon.nature_id))
 
 	mon._initialize_stats(false)

--- a/Services/DatabaseService.gd
+++ b/Services/DatabaseService.gd
@@ -8,7 +8,6 @@ const POKEMON_DIR := "res://Resources/Data/Pokemon"
 const MOVES_DIR := "res://Resources/Data/Moves"
 const TYPES_DIR := "res://Resources/Data/Types"
 const ABILITIES_DIR := "res://Resources/Data/Abilities"
-const NATURES_DIR := "res://Resources/Data/Natures" # opcional, si existe
 const WEATHERS_DIR := "res://Resources/Data/Weather" # opcional, si existe
 const TRAINER_CLASSES_DIR := "res://Resources/Trainer Classes"
 const ITEMS_DIR := "res://Resources/Data/Items"
@@ -85,6 +84,11 @@ func _load_all() -> void:
 			"DatabaseService: no hay items cargados. Comprueba que `res://Resources/Data/Items/` esté en el paquete de exportación."
 		)
 
+	if _weathers_by_id.is_empty():
+		push_error(
+			"DatabaseService: no hay climas cargados. Comprueba que `res://Resources/Data/Weather/` contenga .tres (p. ej. RAIN.tres) y esté en el paquete de exportación."
+		)
+
 func _print_summary() -> void:
 	pass
 
@@ -107,38 +111,30 @@ func _load_types() -> void:
 	)
 
 func _load_abilities() -> void:
+	var loaded := [0]
 	load_resources_from_dir(ABILITIES_DIR, func(res):
-		if res == null: return
-		if not (res is AbilityData): return
-		_abilities_by_id[res.id] = res
+		if res == null:
+			return
+		if not (res is AbilityData):
+			return
+		_abilities_by_id[int(res.id)] = res
 		if typeof(res.internal_name) == TYPE_STRING and res.internal_name != "":
 			_abilities_by_name[res.internal_name.to_lower()] = res
+		loaded[0] += 1
 	)
+	if loaded[0] == 0:
+		push_error("DatabaseService: no se cargaron habilidades desde %s" % ABILITIES_DIR)
 
 func _load_natures() -> void:
-	var natures_loaded := false
-	var dir := DirAccess.open(NATURES_DIR)
-	if dir != null:
-		load_resources_from_dir(NATURES_DIR, func(res):
-			if res == null: return
-			if not (res is NatureData): return
-			_natures_by_id[res.id] = res
-			var key := str(res.id).to_lower()
-			_natures_by_name[key] = res
-		)
-		natures_loaded = _natures_by_id.size() > 0
-
-	if not natures_loaded:
-		# Construye naturalezas en memoria a partir de NaturesEnum si no hay .tres
-		for i in NaturesEnum.Values.size():
-			var nat_id := NaturesEnum.get_id(i)
-			if nat_id == "NONE":
-				continue
-			var nat := NatureData.new()
-			nat.id = nat_id.to_lower()
-			nat.display_name = nat_id.capitalize()
-			_natures_by_id[nat.id] = nat
-			_natures_by_name[nat.id] = nat
+	for i in NaturesEnum.Values.size():
+		var nat_id := NaturesEnum.get_id(i)
+		if nat_id == "NONE":
+			continue
+		var nat := NatureData.new()
+		nat.id = nat_id.to_lower()
+		nat.display_name = nat_id.capitalize()
+		_natures_by_id[nat.id] = nat
+		_natures_by_name[nat.id] = nat
 
 func _load_weathers() -> void:
 	var dir := DirAccess.open(WEATHERS_DIR)
@@ -258,25 +254,7 @@ func _load_resources_by_pattern(dir_path: String, on_loaded: Callable) -> void:
 					on_loaded.call(res)
 		return
 
-	# Para Abilities: intentar cargar del 001 al 232 (rango típico de Gen 1-3)
-	if dir_path == ABILITIES_DIR:
-		for i in range(1, 233):
-			var path := "%s/%03d.tres" % [dir_path, i]
-			if ResourceLoader.exists(path):
-				var res := load(path)
-				if res != null:
-					on_loaded.call(res)
-		return
-
-	# Para Weather: intentar cargar del 01 al 10
-	if dir_path == WEATHERS_DIR:
-		for i in range(1, 11):
-			var path := "%s/%02d.tres" % [dir_path, i]
-			if ResourceLoader.exists(path):
-				var res := load(path)
-				if res != null:
-					on_loaded.call(res)
-		return
+	# Habilidades y climas: archivos con nombre (022-INTIMIDATE.tres, RAIN.tres, …) → DirAccess más abajo.
 
 	# Para Items: índice estático id -> ruta (evita depender de DirAccess en export).
 	if dir_path == ITEMS_DIR:
@@ -434,8 +412,11 @@ func get_all_types_sorted() -> Array[TypeData]:
 	return out
 
 func get_ability(name_or_id) -> Resource:
-	if typeof(name_or_id) == TYPE_INT:
-		return _abilities_by_id.get(name_or_id, null)
+	if name_or_id == null:
+		return null
+	var t := typeof(name_or_id)
+	if t == TYPE_INT or t == TYPE_FLOAT:
+		return _abilities_by_id.get(int(name_or_id), null)
 	var key := str(name_or_id).to_lower()
 	if key.is_valid_int():
 		return _abilities_by_id.get(int(key), null)


### PR DESCRIPTION
Reestructuración del sistema de **efectos persistentes** (`PersistentBattleEffect`) con clasificación por origen, orden de aplicación/visualización separado, cableado de fases de combate y correcciones en la carga de habilidades/climas desde `DatabaseService`.

## Novedades

### Efectos persistentes — modelo base

- **`EffectSource`**: clasificación automática al registrar el efecto (`WEATHER`, `FIELD`, `AILMENT`, `ABILITY`, `ITEM`, `OTHER`) vía `detect_effect_source()` / `classify_from_class_name()`.
- **`get_visual_order()`**: orden de mensajes distinto al de aplicación (FIELD → WEATHER → AILMENT → ABILITY → ITEM → OTHER).
- Hooks por fase: `apply_phase()` y `visualize_phase()` en la base; métodos legacy de modificadores conservados.
- **`get_priority()`** para ordenar la aplicación dentro del mismo origen.

### `BattleEffectController`

- API ampliada: `get_all_effects_to_apply_for()` y `get_all_effects_to_visualize_for()`.
- Ordenación con `_sort_effects_for_apply` (prioridad) y `_sort_effects_for_visualize` (`get_visual_order`).
- **`process_global_phase()`**: procesa efectos globales (campo + lados) y luego por Pokémon activo.
- **`process_phase()`**: efectos scoped a un Pokémon concreto.
- Registro centralizado con `_register_effect()` → `detect_effect_source()` al añadir efectos.
- Limpieza de efectos al terminar (`has_finished()`), incluyendo globales vía `_remove_global_effect_if_finished()`.
- Inicialización más robusta de listas por lado (`Player` / `Enemy`).

### Fases de combate cableadas

| Fase | Momento |
|------|---------|
| `ON_BATTLE_START` | Una vez al entrar en el bucle de turnos (antes del `while`) |
| `ON_INIT_BATTLE_TURN` | Inicio de cada turno (`new_turn()`) |
| `ON_INIT_POKEMON_TURN` | Antes de la acción de cada Pokémon (orden de velocidad) |
| `ON_BEFORE_MOVE` | Antes de ejecutar un movimiento |
| `ON_END_POKEMON_TURN` | Tras la acción de cada Pokémon |
| `ON_END_BATTLE_TURN` | Fin de turno (`end_turn()`) |
| `ON_SWITCH_IN` | Tras el mensaje de cambio en `SwitchEffect.visualize()` |

- Renombrado **`ON_ENTRY` → `ON_BATTLE_START`** para evitar mensajes duplicados de clima/efectos de campo al inicio.

### Efectos concretos

- **Lluvia** (`RainWeatherEffect`): mensaje de inicio en `ON_BATTLE_START`; tick y fin en `ON_END_BATTLE_TURN`.
- **Reflejo** (`ReflectFieldEffect`): mensaje de inicio en `ON_BATTLE_START`; fin en `ON_END_BATTLE_TURN`.
- **Intimidación** (`IntimidateAbilityEffect`):
  - Aplica en `ON_BATTLE_START` (activos al inicio) y `ON_SWITCH_IN` (al entrar).
  - `022-INTIMIDATE.tres` enlazado con `effect_resource`.
  - Lógica de entrada movida fuera de `BattleTurnController` → flujo de `SwitchEffect`.

### Cambios y entradas al campo

- **`SwitchEffect`**: tras el mensaje de cambio, dispara `ON_SWITCH_IN` para el Pokémon que entra.
- Al salir del campo se limpian los efectos persistentes del Pokémon (`_clear_pokemon_effects`).
- **`BattleSpotUI`**: corrección al registrar efectos de habilidad (`_pokemon` en lugar de `pokemon`).

### `DatabaseService` — carga de datos

- **Habilidades**: carga por `DirAccess` (archivos tipo `022-INTIMIDATE.tres`); eliminado el bucle numérico `001–232.tres`.
- **Climas**: mismo patrón; validación de error si no hay climas cargados.
- **Naturalezas**: generadas solo desde `NaturesEnum` (sin carpeta `.tres`).
- **`get_ability()`**: acepta `null`, `int` y `float`.

### Pokémon — habilidad (single source of truth)

- Centralización en `Pokemon._configure_ability()` → `_resolve_ability_id()` + `_apply_ability_from_database()`.
- Eliminados fallbacks duplicados en otros puntos del runtime.
- **`PokemonRuntimeSerde`**: usa `_apply_ability_from_database()` tras deserializar.

### Herramientas de prueba (`TestBattle`)

- Nuevo **`BattleDebugEffectSeeder`**: siembra lluvia + Reflejo (jugador) + veneno en el activo para validar orden visual de fin de turno (Reflejo → Lluvia → Veneno).
- Flag `@export debug_seed_persistent_effects` en `TestBattle.tscn`.
- Combate fijo actualizado: **Growlithe** (Intimidación) + **Ekans** en banca vs **Gastly** (sustituye Rattata).
- Helper `_start_test_battle()` para activar el seeder antes de lanzar el combate.