### PR TITLE
PBI AB#734 - [Combate] Implementar Forcejeo cuando no hay movimientos legales

### DIFF
--- a/Scenes/Battle/TestBattle.tscn
+++ b/Scenes/Battle/TestBattle.tscn
@@ -8,8 +8,8 @@
 script = ExtResource("1_tse6d")
 use_fixed_substitute_test = true
 use_fixed_rattata_vs_gastly = false
-debug_force_ailment_apply = true
-debug_seed_persistent_effects = false
+debug_rattata_test_bite = false
+debug_zero_pp = false
 
 [node name="Player" type="Node" parent="." unique_id=1369444140]
 script = ExtResource("3_bfl41")

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -3,7 +3,7 @@ extends Node2D
 const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 
 @export_group("Equipos de prueba")
-## Si true, lanza 1vs1 salvaje: Clefairy (Sustituto + Canto Mortal + Destructor + Látigo) vs Pidgey (Sustituto + Bostezo/Picotazo Veneno/Tornado).
+## Si true, lanza 1vs1 salvaje: Clefairy (Sustituto + Anulación + Destructor + Látigo) vs Pidgey (solo Bostezo).
 @export var use_fixed_substitute_test: bool = false
 ## Si true, lanza un 1vs1 salvaje fijo: Rattata Nv.20 vs Pidgey Nv.20 (pruebas ailments).
 @export var use_fixed_rattata_vs_gastly: bool = true
@@ -13,6 +13,9 @@ const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 @export var debug_rattata_test_bite: bool = true
 ## Si true, el ailment del movimiento de prueba siempre se aplica (omite el %).
 @export var debug_force_ailment_apply: bool = false
+## Si true, todos los movimientos del combate fijo empiezan con 0 PP (prueba Forcejeo por PP).
+## Desactivar para el escenario Sustituto/Anulación (Forcejeo vía Anulación, no por PP).
+@export var debug_zero_pp: bool = false
 
 @export_group("Debug efectos persistentes")
 ## Al iniciar combate: lluvia activa, Reflejo en el lado del jugador y veneno en el primer activo.
@@ -42,6 +45,11 @@ func _ready() -> void:
 	if use_fixed_substitute_test:
 		_setup_fixed_substitute_test_parties()
 		_print_substitute_test_guide()
+		if debug_zero_pp:
+			push_warning(
+				"TestBattle: debug_zero_pp fuerza Forcejeo al pulsar LUCHAR. "
+				+ "Desactívalo para probar Anulación → Forcejeo."
+			)
 		await wildFixedSubstituteTestBattle()
 		return
 	if use_fixed_rattata_vs_gastly:
@@ -55,6 +63,8 @@ func _ready() -> void:
 		print(">>> Combate fijo: Rattata (Otra Vez + Bostezo + %s%s) vs Pidgey (Anulación + Bostezo + Tornado + Látigo)" % [move_label, chance_note])
 		if debug_pidgey_status_only:
 			print(">>> debug_pidgey_status_only: Pidgey solo lleva Anulación + Bostezo + Látigo.")
+		if debug_zero_pp:
+			print(">>> debug_zero_pp: todos los movimientos a 0 PP — pulsa LUCHAR para Forcejeo.")
 		await wildFixedRattataGastlyBattle()
 		return
 	# Lanzar combates en bucle para testing continuo
@@ -185,11 +195,12 @@ func _create_substitute_test_player_instance() -> Pokemon:
 	pkmn.is_wild = false
 	pkmn.custom_move_ids = [
 		MovesEnum.Values.SUBSTITUTE,
-		MovesEnum.Values.PERISH_SONG,
+		MovesEnum.Values.DISABLE,
 		MovesEnum.Values.POUND,
 		MovesEnum.Values.TAIL_WHIP,
 	]
 	pkmn._post_init()
+	_apply_debug_zero_pp(pkmn)
 	return pkmn
 
 
@@ -199,26 +210,25 @@ func _create_substitute_test_enemy_instance() -> Pokemon:
 	pkmn.level = 20
 	pkmn.is_wild = true
 	pkmn.custom_move_ids = [
-		MovesEnum.Values.SUBSTITUTE,
-		MovesEnum.Values.PERISH_SONG,
 		MovesEnum.Values.YAWN,
-		MovesEnum.Values.POISON_STING,
 	]
 	pkmn._post_init()
+	_apply_debug_zero_pp(pkmn)
 	return pkmn
 
 
 func _print_substitute_test_guide() -> void:
 	var ailment_note := " (ailments garantizados)" if debug_force_ailment_apply else ""
-	print(">>> Combate Sustituto: Clefairy (Sustituto + Canto Mortal + Destructor + Látigo) vs Pidgey (Sustituto + Canto Mortal + Bostezo + Picotazo Veneno)%s" % ailment_note)
-	print(">>> Validación manual sugerida:")
-	print(">>>   1) Turno 1 — Clefairy usa Sustituto: pierde ~1/4 PS máx, mensaje «creó un sustituto».")
-	print(">>>   2) Pidgey puede usar Sustituto; Clefairy con Destructor rompe el muñeco rival.")
-	print(">>>   3) Con sustituto activo — Pidgey usa Bostezo o Picotazo Veneno: «¡Pero falló!», sin estado en Clefairy.")
-	print(">>>   4) Pidgey usa Tornado varias veces: baja PS del muñeco, no los de Clefairy hasta que se rompa.")
-	print(">>>   5) Tras romperse — Bostezo/Veneno deberían aplicarse con normalidad.")
-	print(">>>   6) Segundo Sustituto sin romper el primero: «¡Pero falló!».")
-	print(">>>   7) Edge: Bostezo antes de Sustituto → al final del turno Clefairy sí puede dormirse (bostezo previo).")
+	print(">>> Combate Sustituto: Clefairy (Sustituto + Anulación + Destructor + Látigo) vs Pidgey (solo Bostezo)%s" % ailment_note)
+	if debug_zero_pp:
+		print(">>> AVISO: debug_zero_pp=ON → Forcejeo inmediato. Ponlo en false para probar Anulación.")
+	else:
+		print(">>> Prueba Anulación → Forcejeo (debug_zero_pp desactivado):")
+		print(">>>   1) Turno 1 — Pidgey (más rápido) usa Bostezo; Clefairy elige Anulación.")
+		print(">>>   2) Turno 2 — Pidgey no puede usar Bostezo → Forcejeo automático (IA).")
+	print(">>> Otros (Sustituto):")
+	print(">>>   · Clefairy usa Sustituto: pierde ~1/4 PS máx, mensaje «creó un sustituto».")
+	print(">>>   · Con sustituto activo — Forcejeo de Pidgey daña al muñeco.")
 
 
 ## 1vs1 salvaje: Pikachu♂ vs Clefairy♀ con Atracción; ambos equipos tienen banca para probar cambios.
@@ -332,6 +342,8 @@ func singleTrainerBattle():
 func _start_test_battle(participants: Array[BattleParticipant], rules: BattleRules) -> String:
 	if debug_seed_persistent_effects:
 		BattleDebugEffectSeeder.enable()
+	if debug_zero_pp:
+		_apply_debug_zero_pp_to_participants(participants)
 	BattleDebugAilmentTest.force_ailment_apply = debug_force_ailment_apply
 	var winner: String = await DisplayManager.start_battle(participants, rules)
 	BattleDebugAilmentTest.force_ailment_apply = false
@@ -354,6 +366,7 @@ func _create_rattata_ailment_test_instance() -> Pokemon:
 		MovesEnum.Values.TAIL_WHIP,
 	]
 	pkmn._post_init()
+	_apply_debug_zero_pp(pkmn)
 	return pkmn
 
 
@@ -376,7 +389,29 @@ func _create_pidgey_trap_test_instance() -> Pokemon:
 			MovesEnum.Values.TAIL_WHIP,
 		]
 	pkmn._post_init()
+	_apply_debug_zero_pp(pkmn)
 	return pkmn
+
+
+func _apply_debug_zero_pp(pkmn: Pokemon) -> void:
+	if not debug_zero_pp or pkmn == null:
+		return
+	for mv in pkmn.movements:
+		if mv != null:
+			mv.pp_actual = 0
+
+
+func _apply_debug_zero_pp_to_participants(participants: Array[BattleParticipant]) -> void:
+	for participant in participants:
+		if participant == null:
+			continue
+		for bp in participant.pokemon_team:
+			if bp == null:
+				continue
+			for mv in bp.get_available_moves():
+				if mv != null and mv.base_data != null:
+					mv.base_data.pp_actual = 0
+	print(">>> debug_zero_pp: PP a 0 en todos los movimientos de combate activos.")
 
 
 ## Party en escena para `player` / `wildPokemons` (combate fijo por battler opcional).

--- a/Scripts/Battle/core/Battle Choices/BattleStruggleChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleStruggleChoice.gd
@@ -1,0 +1,45 @@
+class_name BattleStruggleChoice
+extends BattleMoveChoice
+
+var _struggle_move: BattleMove = null
+
+
+static func create_move_for(pokemon: BattlePokemon) -> BattleMove:
+	var move_data: MoveData = DatabaseService.get_move(MovesEnum.Values.STRUGGLE)
+	if move_data == null:
+		push_error("BattleStruggleChoice: Forcejeo (165) no encontrado en DatabaseService")
+		return null
+	return Move.new(move_data).to_battle_move(pokemon)
+
+
+static func create_for(pokemon: BattlePokemon) -> BattleStruggleChoice:
+	var choice := BattleStruggleChoice.new()
+	choice.pokemon = pokemon
+	choice._struggle_move = create_move_for(pokemon)
+	if choice._struggle_move != null:
+		var selector := BattleTargetSelector.new()
+		choice.targets = selector.resolve_targets(choice._struggle_move, pokemon, null)
+	return choice
+
+
+static func create_if_needed(pokemon: BattlePokemon) -> BattleStruggleChoice:
+	var filter := BattleEffectController.get_move_selection_filter(pokemon)
+	if filter.requires_struggle():
+		return create_for(pokemon)
+	return null
+
+
+func get_move() -> BattleMove:
+	return _struggle_move
+
+
+func resolve() -> Array[BattleHandler]:
+	var handlers: Array[BattleHandler] = []
+	var move_instance := get_move()
+	if move_instance == null or targets.is_empty():
+		return handlers
+
+	for target_entry in targets:
+		handlers.append(BattleStruggleMoveHandler.new(move_instance, pokemon, target_entry))
+
+	return handlers

--- a/Scripts/Battle/core/Battle Choices/BattleStruggleChoice.gd.uid
+++ b/Scripts/Battle/core/Battle Choices/BattleStruggleChoice.gd.uid
@@ -1,0 +1,1 @@
+uid://bbv2804gpys3i

--- a/Scripts/Battle/core/Battle Effects/Persistent/Ailments/EncoreAilmentEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Ailments/EncoreAilmentEffect.gd
@@ -94,6 +94,8 @@ func apply_phase(pokemon: BattlePokemon, phase: Phases, ctx: BattlePhaseContext 
 		effect_success = false
 		if not is_active():
 			return
+		if ctx.move.get_id() == MovesEnum.Values.STRUGGLE:
+			return
 		if ctx.move.get_id() != _locked_move_id:
 			effect_success = true
 			_rejected_move_id = ctx.move.get_id()
@@ -108,6 +110,8 @@ func apply_phase(pokemon: BattlePokemon, phase: Phases, ctx: BattlePhaseContext 
 			return
 		applied = true
 		effect_success = false
+		if move.get_id() == MovesEnum.Values.STRUGGLE:
+			return
 		if move.get_id() != _locked_move_id or not _is_locked_move_usable(pokemon):
 			effect_success = true
 			_rejected_move_id = move.get_id()

--- a/Scripts/Battle/core/Battle IAs/BattleIA_Easy.gd
+++ b/Scripts/Battle/core/Battle IAs/BattleIA_Easy.gd
@@ -24,6 +24,10 @@ func decide_action(pokemon: BattlePokemon) -> BattleChoice:
 	if moves.is_empty():
 		return BattlePassChoice.new()
 
+	var struggle := BattleStruggleChoice.create_if_needed(pokemon)
+	if struggle != null:
+		return struggle
+
 	var legal_indices := get_selectable_move_indices(pokemon)
 	if legal_indices.is_empty():
 		return BattlePassChoice.new()
@@ -58,6 +62,9 @@ func _select_random_move(
 	if indices.is_empty():
 		indices = get_selectable_move_indices(pokemon)
 	if indices.is_empty():
+		var struggle := BattleStruggleChoice.create_if_needed(pokemon)
+		if struggle != null:
+			return struggle
 		return BattlePassChoice.new()
 	var index: int = indices[randi() % indices.size()]
 	var move = moves[index]

--- a/Scripts/Battle/core/Battle IAs/BattleIA_Wild.gd
+++ b/Scripts/Battle/core/Battle IAs/BattleIA_Wild.gd
@@ -23,6 +23,10 @@ func decide_action(pokemon: BattlePokemon) -> BattleChoice:
 	if moves.is_empty():
 		return BattlePassChoice.new()
 
+	var struggle := BattleStruggleChoice.create_if_needed(pokemon)
+	if struggle != null:
+		return struggle
+
 	var legal_indices := get_selectable_move_indices(pokemon)
 	if legal_indices.is_empty():
 		return BattlePassChoice.new()

--- a/Scripts/Battle/core/BattlePokemon.gd
+++ b/Scripts/Battle/core/BattlePokemon.gd
@@ -146,6 +146,10 @@ func commit_move_usage(move: BattleMove) -> void:
 	if move == null:
 		return
 	last_used_move_id = move.get_id()
+	if move.get_id() == MovesEnum.Values.STRUGGLE:
+		return
+	if move.base_data != null:
+		move.base_data.use_pp()
 
 
 func clear_last_used_move() -> void:
@@ -287,6 +291,10 @@ func decide_random_action() -> BattleChoice:
 	var moves = get_available_moves()
 	if moves.is_empty():
 		return BattleChoice.new()
+
+	var struggle := BattleStruggleChoice.create_if_needed(self)
+	if struggle != null:
+		return struggle
 
 	var legal_indices := get_selectable_move_indices()
 	if legal_indices.is_empty():

--- a/Scripts/Battle/core/Handlers/BattleStruggleMoveHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattleStruggleMoveHandler.gd
@@ -1,0 +1,54 @@
+extends BattleMoveHandler
+
+class_name BattleStruggleMoveHandler
+
+const MAGIC_GUARD_ABILITY_ID := 98
+
+var damage: DamageEffect = null
+var recoil_amount: int = 0
+var _applied_recoil: bool = false
+
+
+func _apply() -> void:
+	var target_pokemon: BattlePokemon = (
+		target.get_pokemon().get_active_battle_pokemon()
+		if target.get_pokemon() != null
+		else null
+	)
+	if target_pokemon == null:
+		return
+
+	damage = move.calculate_damage(target_pokemon)
+	show_effectiveness = false
+	damage.apply()
+	_finalize_defender_move_resolution(damage)
+
+	recoil_amount = maxi(1, user.total_hp / 4)
+	_applied_recoil = not _has_magic_guard(user)
+
+
+func _visualize(ui: BattleUI) -> void:
+	if damage != null:
+		await damage.visualize(ui)
+		if damage.is_critical:
+			await ui.show_critical_hit_message()
+
+	if not _applied_recoil or user == null:
+		return
+
+	var active_user: BattlePokemon = user.get_active_battle_pokemon()
+	if active_user == null:
+		return
+
+	var spot: BattleSpot = active_user.resolve_battle_spot()
+	if spot == null:
+		return
+
+	await spot.play_hit_animation()
+	active_user.hp = maxi(active_user.hp - recoil_amount, 0)
+	await spot.apply_damage(recoil_amount)
+	await ui.show_struggle_recoil_message(active_user)
+
+
+func _has_magic_guard(pokemon: BattlePokemon) -> bool:
+	return pokemon.ability != null and int(pokemon.ability.id) == MAGIC_GUARD_ABILITY_ID

--- a/Scripts/Battle/core/Handlers/BattleStruggleMoveHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/BattleStruggleMoveHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://dccuknk6awj8

--- a/Scripts/Battle/core/MoveSelectionFilter.gd
+++ b/Scripts/Battle/core/MoveSelectionFilter.gd
@@ -42,3 +42,8 @@ func get_selectable_indices() -> Array[int]:
 		if not is_index_blocked(i):
 			out.append(i)
 	return out
+
+
+## True cuando hay moveset pero ningún índice es elegible (PP agotado y/o bloqueado por efectos).
+func requires_struggle() -> bool:
+	return not moves.is_empty() and get_selectable_indices().is_empty()

--- a/Scripts/Battle/core/Utils/AccuracyUtils.gd
+++ b/Scripts/Battle/core/Utils/AccuracyUtils.gd
@@ -1,6 +1,8 @@
 class_name AccuracyUtils
 
 static func check_hit(move: BattleMove, user: BattlePokemon, target: BattlePokemon) -> bool:
+	if move.get_id() == MovesEnum.Values.STRUGGLE:
+		return true
 	var base_accuracy = move.get_accuracy()
 	# Movimientos sin precisión (0) siempre impactan: usados para efectos de campo/side
 	if base_accuracy <= 0 or !target:

--- a/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
+++ b/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
@@ -11,6 +11,7 @@ static func calculate(move: BattleMove, user: BattlePokemon, target: BattlePokem
 	var def = target.get_modified_stat(def_stat)
 	var level = user.get_level()
 	var power = move.get_power()
+	var is_struggle := move.get_id() == MovesEnum.Values.STRUGGLE
 
 	# Aplicar modificadores de potencia (atacante, globales)
 	var power_data = ModifierEngine.apply_power(move, user, target, power)
@@ -19,17 +20,21 @@ static func calculate(move: BattleMove, user: BattlePokemon, target: BattlePokem
 	# Paso 1: Daño base
 	var base = (((2 * level / 5.0 + 2) * power * atk / def) / 50.0) + 2
 
-	# Paso 2: STAB
-	var stab = 1.5 if move.get_type() == user.get_type1() or move.get_type() == user.get_type2() else 1.0
+	# Paso 2: STAB (Forcejeo es typeless en Gen 5)
+	var stab := 1.0
+	if not is_struggle:
+		stab = 1.5 if move.get_type() == user.get_type1() or move.get_type() == user.get_type2() else 1.0
 
 	# Paso 3: Crítico
 	var is_crit = is_critical_hit(move.get_critical_rate())
 	var crit = 2.0 if is_crit else 1.0
 
-	# Paso 4: Efectividad
-	var effectiveness = TypeEffectivenessUtils.get_multiplier(
-		move.get_type(), target.get_type1(), target.get_type2()
-	)
+	# Paso 4: Efectividad (Forcejeo siempre ×1)
+	var effectiveness := 1.0
+	if not is_struggle:
+		effectiveness = TypeEffectivenessUtils.get_multiplier(
+			move.get_type(), target.get_type1(), target.get_type2()
+		)
 
 	# Paso 5: Variación aleatoria
 	var random_value = randi_range(217, 255)

--- a/Scripts/Battle/ui/BattleMessageController.gd
+++ b/Scripts/Battle/ui/BattleMessageController.gd
@@ -147,6 +147,29 @@ func get_used_move_message(user: BattlePokemon, move: BattleMove) -> Dictionary:
 		"wait_time": 0.5
 	}
 
+
+func get_no_moves_left_message(pokemon: BattlePokemon) -> Dictionary:
+	if pokemon == null:
+		return {}
+	var subject := pokemon.get_battle_target_name()
+	if not subject.is_empty():
+		subject = subject[0].to_upper() + subject.substr(1)
+	return {
+		"type": "display",
+		"text": "¡%s no le quedan movimientos!" % subject,
+		"wait_time": 1.0,
+	}
+
+
+func get_struggle_recoil_message(pokemon: BattlePokemon) -> Dictionary:
+	if pokemon == null:
+		return {}
+	return {
+		"type": "display",
+		"text": "¡%s se resiente del retroceso!" % pokemon.get_battle_display_name(true),
+		"wait_time": 1.0,
+	}
+
 func get_start_ailment_message(
 	user: BattlePokemon,
 	ailment_id: AilmentsEnum.Values,

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -628,6 +628,9 @@ func show_moves_menu_for(pokemon: BattlePokemon) -> BattleChoice:
 
 func show_move_selection(pokemon: BattlePokemon) -> BattleMoveChoice:
 	var selection := BattleEffectController.get_move_selection_filter(pokemon)
+	if selection.requires_struggle():
+		await show_no_moves_left_message(pokemon)
+		return await _finish_move_selection(pokemon, BattleStruggleChoice.create_for(pokemon))
 	if selection.auto_submit_index >= 0:
 		var forced_choice := BattleMoveChoice.new()
 		forced_choice.move_index = selection.auto_submit_index
@@ -716,6 +719,16 @@ func play_intro_sequence(rules,player_pokemon,enemy_pokemon,player_trainers,enem
 
 func show_used_move_message(user: BattlePokemon, move: BattleMove) -> void:
 	await show_message_from_dict(message_controller.get_used_move_message(user, move))
+
+
+func show_no_moves_left_message(pokemon: BattlePokemon) -> void:
+	await show_message_from_dict(message_controller.get_no_moves_left_message(pokemon))
+	clear_message_box()
+
+
+func show_struggle_recoil_message(pokemon: BattlePokemon) -> void:
+	await show_message_from_dict(message_controller.get_struggle_recoil_message(pokemon))
+	clear_message_box()
 
 func show_failed_move_message(user: BattlePokemon) -> void:
 	await show_message_from_dict(message_controller.get_failed_move_message(user))

--- a/Scripts/Battle/ui/MovesMenu.gd
+++ b/Scripts/Battle/ui/MovesMenu.gd
@@ -25,6 +25,7 @@ func _ready():
 func show_for(pokemon: BattlePokemon) -> BattleMoveChoice:
 	current_pokemon = pokemon
 	moves = pokemon.get_available_moves()
+	var filter := BattleEffectController.get_move_selection_filter(pokemon)
 	unlock_visual_focus()
 	for i in 4:
 		if i < moves.size():
@@ -32,7 +33,7 @@ func show_for(pokemon: BattlePokemon) -> BattleMoveChoice:
 			var button = move_buttons[i]
 			button.visible = true
 			button.get_node("Label").setText(move.get_name())
-			button.disabled = false
+			button.disabled = filter.is_index_blocked(i)
 
 			# Estilo visual según tipo (posición vertical en el sprite)
 			button.get("theme_override_styles/normal").region_rect.position.y = 46 * (move.get_type().id - 1)
@@ -43,6 +44,11 @@ func show_for(pokemon: BattlePokemon) -> BattleMoveChoice:
 	# Usar el último índice de movimiento del Pokémon específico
 	# Validar que esté dentro del rango de movimientos disponibles
 	var initial_index = clamp(pokemon.last_move_index, 0, moves.size() - 1)
+	if filter.is_index_blocked(initial_index):
+		for i in range(moves.size()):
+			if not filter.is_index_blocked(i):
+				initial_index = i
+				break
 	move_buttons[initial_index].grab_focus()
 	visible = true
 	set_process_input(true)


### PR DESCRIPTION
## PBI 734 — Forcejeo (Gen 5)

### Resumen

Cuando un Pokémon puede actuar pero no tiene movimientos legales (PP agotado y/o bloqueados por Anulación, Tormento, Otra Vez o Mofa), usa **Forcejeo** automáticamente en lugar de pasar turno.

---

### Nuevos archivos

- `Scripts/Battle/core/Battle Choices/BattleStruggleChoice.gd` — Choice sintético que carga Forcejeo (id 165) como movimiento efímero, targets `RANDOM_ENEMY`, `resolve()` sin chequeo de precisión.
- `Scripts/Battle/core/Handlers/BattleStruggleMoveHandler.gd` — Daño typeless + retroceso 1/4 HP máx (mín. 1); Muro Mágico (id 98) lo evita; Cabeza Roca no.

### Lógica de combate

- `MoveSelectionFilter.requires_struggle()` cuando hay moveset pero `get_selectable_indices()` está vacío.
- `DamageCalculator_Gen5` — Forcejeo sin STAB ni multiplicador de efectividad (×1 siempre).
- `AccuracyUtils` — Forcejeo siempre impacta.
- `BattlePokemon.commit_move_usage()` — Consume PP al usar un movimiento; Forcejeo no consume PP.
- `EncoreAilmentEffect` — Permite Forcejeo en validación/ejecución cuando Otra Vez bloquea el único movimiento usable.

### UI y mensajes

- Al pulsar **LUCHAR** sin movimientos legales: salta el menú y muestra **«¡A X no le quedan movimientos!»** (solo jugador, vía `get_battle_target_name()`).
- Tras el daño: **«¡X ha usado Forcejeo!»**.
- Tras animar la barra de retroceso: **«¡X se resiente del retroceso!»**.
- `MovesMenu` deshabilita movimientos bloqueados por el filter.

### Integración

- `BattleUI`, `BattlePokemon`, `BattleIA_Wild`, `BattleIA_Easy` — Fallback a `BattleStruggleChoice` en lugar de `BattlePassChoice`.
- Log de turno: **«usará Forcejeo»** en lugar de **«pasará»**.

### TestBattle

- Flag `debug_zero_pp` para probar Forcejeo por PP agotado.
- Escenario Sustituto/Anulación: Clefairy (Sustituto + Anulación + Destructor + Látigo) vs Pidgey (solo Bostezo).
- `debug_zero_pp` desactivado por defecto en escena para probar Anulación → Forcejeo.
- Aviso en consola si `debug_zero_pp` está activo en el escenario Sustituto.