### PR TITLE
AB#735 - Switch al debilitarse el Pokémon activo

### DIFF
--- a/Scenes/Battle/TestBattle.tscn
+++ b/Scenes/Battle/TestBattle.tscn
@@ -6,7 +6,9 @@
 
 [node name="TestBattle" type="Node2D" unique_id=764670732]
 script = ExtResource("1_tse6d")
-use_fixed_substitute_test = true
+use_forced_switch_player_test = true
+use_forced_switch_trainer_test = false
+use_fixed_substitute_test = false
 use_fixed_rattata_vs_gastly = false
 debug_rattata_test_bite = false
 debug_zero_pp = false

--- a/Scripts/Battle/Battle.gd
+++ b/Scripts/Battle/Battle.gd
@@ -87,8 +87,9 @@ func show_trainers_and_pokemon():
 #
 	#
 func show_hp_bars():
-	await battle_ui.show_enemy_hp_bar(battle_controller.enemy_side.get_active_pokemons())
-	await get_tree().create_timer(0.5).timeout
+	if battle_controller.rules == null or battle_controller.rules.type != BattleRules.BattleTypes.TRAINER:
+		await battle_ui.show_enemy_hp_bar(battle_controller.enemy_side.get_active_pokemons())
+		await get_tree().create_timer(0.5).timeout
 	await battle_ui.show_player_hp_bar(battle_controller.player_side.get_active_pokemons())
 	await get_tree().create_timer(0.5).timeout
 

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -3,6 +3,10 @@ extends Node2D
 const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 
 @export_group("Equipos de prueba")
+## Si true, lanza 1vs1 salvaje con party jugador 2+ para probar cambio forzado por KO (AC1).
+@export var use_forced_switch_player_test: bool = false
+## Si true, lanza 1vs1 entrenador con party 2+ (jugador y rival) para probar cambio forzado por KO.
+@export var use_forced_switch_trainer_test: bool = false
 ## Si true, lanza 1vs1 salvaje: Clefairy (Sustituto + Anulación + Destructor + Látigo) vs Pidgey (solo Bostezo).
 @export var use_fixed_substitute_test: bool = false
 ## Si true, lanza un 1vs1 salvaje fijo: Rattata Nv.20 vs Pidgey Nv.20 (pruebas ailments).
@@ -41,6 +45,15 @@ var _bootstrapped_display_manager: DisplayManager = null
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	if not await _ensure_display_manager():
+		return
+	if use_forced_switch_player_test:
+		_setup_forced_switch_player_test_parties()
+		_print_forced_switch_player_guide()
+		await forcedSwitchPlayerTestBattle()
+		return
+	if use_forced_switch_trainer_test:
+		_print_forced_switch_trainer_guide()
+		await forcedSwitchTrainerTestBattle()
 		return
 	if use_fixed_substitute_test:
 		_setup_fixed_substitute_test_parties()
@@ -174,6 +187,112 @@ func wildFixedSubstituteTestBattle() -> void:
 	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
 	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla Sustituto terminada. Ganador: %s" % winner)
+
+
+func forcedSwitchTrainerTestBattle() -> void:
+	var player_participant := _create_forced_switch_test_strong_player_participant()
+	var trainer_participant := _create_forced_switch_test_trainer_participant()
+	var rules := BattleRules.new(BattleRules.BattleTypes.TRAINER, BattleRules.BattleModes.SINGLE)
+	var participants: Array[BattleParticipant] = [player_participant, trainer_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla cambio forzado (trainer) terminada. Ganador: %s" % winner)
+
+
+func _create_forced_switch_test_strong_player_participant() -> BattleParticipant:
+	var charmander := Pokemon.new()
+	charmander.pokemon_id = PokemonsEnum.Values.CHARMANDER as PokemonsEnum.Values
+	charmander.level = 28
+	charmander.is_wild = false
+	charmander.custom_move_ids = [MovesEnum.Values.EMBER, MovesEnum.Values.SCRATCH, MovesEnum.Values.TAIL_WHIP]
+	charmander._post_init()
+	var squirtle := Pokemon.new()
+	squirtle.pokemon_id = PokemonsEnum.Values.SQUIRTLE as PokemonsEnum.Values
+	squirtle.level = 28
+	squirtle.is_wild = false
+	squirtle.custom_move_ids = [MovesEnum.Values.WATER_GUN, MovesEnum.Values.TACKLE]
+	squirtle._post_init()
+	var lead: BattlePokemon = charmander.to_battle_pokemon()
+	var bench: BattlePokemon = squirtle.to_battle_pokemon()
+	lead.controllable = true
+	bench.controllable = true
+	var participant := BattleParticipant.new([lead, bench])
+	participant.is_player = true
+	participant.name = "Jugador"
+	return participant
+
+
+func _create_forced_switch_test_trainer_participant() -> BattleParticipant:
+	var ia := BattleIA_Easy.new()
+	var lead: BattlePokemon = _create_forced_switch_test_player_lead(PokemonsEnum.Values.RATTATA).to_battle_pokemon()
+	var bench: BattlePokemon = _create_forced_switch_test_player_lead(PokemonsEnum.Values.BULBASAUR).to_battle_pokemon()
+	lead.setIA(ia)
+	bench.setIA(ia)
+	lead.controllable = false
+	bench.controllable = false
+	var participant := BattleParticipant.new([lead, bench])
+	participant.ai_controller = ia
+	participant.is_trainer = true
+	participant.name = "Entrenador"
+	return participant
+
+
+func _print_forced_switch_trainer_guide() -> void:
+	print(">>> Test cambio forzado (rival): Charmander + Squirtle (Nv.28) vs Rattata + Bulbasaur (Nv.8, entrenador).")
+	print(">>> Debilita al Rattata rival → prompt de cambio opcional + envío automático de Bulbasaur.")
+
+
+func forcedSwitchPlayerTestBattle() -> void:
+	var player_participant := _create_fixed_player_participant()
+	if wildPokemons == null or wildPokemons.party.is_empty():
+		push_error("TestBattle: forcedSwitchPlayerTestBattle sin rival en WildPokemons.")
+		return
+	var wild_bp: BattlePokemon = wildPokemons.party[0].to_battle_pokemon()
+	wild_bp.is_wild = true
+	var wild_participant: BattleParticipant = BattleParticipantWild.new([wild_bp])
+	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.SINGLE)
+	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla cambio forzado (jugador) terminada. Ganador: %s" % winner)
+
+
+func _setup_forced_switch_player_test_parties() -> void:
+	if player != null:
+		player.party.clear()
+		player.add_pokemon_to_party(
+			_create_forced_switch_test_player_lead(PokemonsEnum.Values.RATTATA, 20)
+		)
+		player.add_pokemon_to_party(
+			_create_forced_switch_test_player_lead(PokemonsEnum.Values.BULBASAUR)
+		)
+	if wildPokemons != null:
+		wildPokemons.party.clear()
+		wildPokemons.add_pokemon_to_party(_create_forced_switch_test_enemy())
+
+
+func _create_forced_switch_test_player_lead(species_id: int, level: int = 8) -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = species_id as PokemonsEnum.Values
+	pkmn.level = level
+	pkmn.is_wild = false
+	pkmn.custom_move_ids = [MovesEnum.Values.TACKLE, MovesEnum.Values.TAIL_WHIP]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_forced_switch_test_enemy() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.PIDGEY as PokemonsEnum.Values
+	pkmn.level = 8
+	pkmn.is_wild = true
+	pkmn.custom_move_ids = [MovesEnum.Values.GUST, MovesEnum.Values.TACKLE]
+	pkmn._post_init()
+	return pkmn
+
+
+func _print_forced_switch_player_guide() -> void:
+	print(">>> Test cambio forzado (jugador): Rattata (Nv.20) + Bulbasaur (Nv.8) vs Pidgey (Nv.8).")
+	print(">>> Deja que el rival debilite al activo → debe abrirse Party obligatoria (sin cancelar).")
+	print(">>> Elige Bulbasaur (o el otro vivo) y comprueba mensaje de entrada + ON_SWITCH_IN.")
 
 
 func _setup_fixed_substitute_test_parties() -> void:
@@ -522,6 +641,20 @@ func _create_random_player_participant(num_pokemon: int = 1) -> BattleParticipan
 	var participant := BattleParticipant.new(player_team)
 	participant.is_player = true
 	participant.name = "Jugador"
+	return participant
+
+
+func _create_random_trainer_participant(num_pokemon: int = 1) -> BattleParticipant:
+	var trainer_team: Array[BattlePokemon] = []
+	var ia := BattleIA_Easy.new()
+	for i in num_pokemon:
+		var bp := _create_random_pokemon(false)
+		bp.setIA(ia)
+		trainer_team.append(bp)
+	var participant := BattleParticipant.new(trainer_team)
+	participant.ai_controller = ia
+	participant.is_trainer = true
+	participant.name = "Entrenador"
 	return participant
 
 #

--- a/Scripts/Battle/core/Battle Choices/BattleSwitchChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleSwitchChoice.gd
@@ -6,6 +6,8 @@ var side: BattleSide = null
 var outgoing_pokemon: BattlePokemon = null
 var incoming_pokemon: BattlePokemon = null
 var origin_spot_index: int = -1
+var target_spot: BattleSpot = null
+var forced_by_faint: bool = false
 
 func get_priority() -> int:
 	return 6 # En los juegos oficiales, cambiar tiene prioridad 6
@@ -16,12 +18,12 @@ func resolve() -> Array[BattleHandler]:
 	if side_ref == null:
 		print("[SWITCH] Side inválido")
 		return []
-	var spot := pokemon.battle_spot
+	var spot := _resolve_target_spot(side_ref)
 	if spot == null:
 		print("[SWITCH] Spot de origen inválido")
 		return []
 	var current := outgoing_pokemon if outgoing_pokemon != null else spot.get_active_pokemon()
-	if TrapAilmentEffect.is_trapped(current):
+	if not forced_by_faint and TrapAilmentEffect.is_trapped(current):
 		print("[SWITCH] Pokémon atrapado, no puede cambiar")
 		return []
 	var target_idx := target_index
@@ -45,3 +47,13 @@ func resolve() -> Array[BattleHandler]:
 
 	var handler = BattleSwitchHandler.new(side_ref, spot, current, incoming, side_ref.battle_rules)
 	return [handler]
+
+
+func _resolve_target_spot(side_ref: BattleSide) -> BattleSpot:
+	if target_spot != null:
+		return target_spot
+	if pokemon != null and pokemon.battle_spot != null:
+		return pokemon.battle_spot
+	if origin_spot_index >= 0 and side_ref != null and origin_spot_index < side_ref.battle_spots.size():
+		return side_ref.battle_spots[origin_spot_index]
+	return null

--- a/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd
@@ -16,22 +16,56 @@ func _init(_side: BattleSide, _spot: BattleSpot, _out: BattlePokemon, _in: Battl
 
 func apply():
 	if out_pokemon:
-		# Al salir del campo, sus efectos persistentes de combate dejan de estar activos.
 		var effects_ctrl := BattleEffectController.get_instance()
 		if effects_ctrl != null:
 			effects_ctrl._clear_pokemon_effects(out_pokemon)
 		out_pokemon.in_battle = false
-	if spot and in_pokemon:
-		in_pokemon.clear_last_used_move()
-		spot.load_active_pokemon(in_pokemon, rules)
+	if not _is_enemy_trainer_send_in():
+		_load_incoming_pokemon()
 
 func visualize(ui):
+	if _is_enemy_trainer_send_in():
+		var trainer_name := _resolve_trainer_name()
+		var incoming_name := in_pokemon.get_display_name() if in_pokemon else "(ninguno)"
+		await ui.show_trainer_send_in_display(trainer_name, incoming_name)
+		_load_incoming_pokemon()
+		await _process_switch_in()
+		print("[SWITCH] Entra %s (envío entrenador)" % incoming_name)
+		return
+
 	var out_name = out_pokemon.get_name() if out_pokemon else "(ninguno)"
 	var in_name = in_pokemon.get_name() if in_pokemon else "(ninguno)"
 
 	await ui.show_switch_message(side.to_string(), in_name)
 	print("[SWITCH] Sale %s, entra %s" % [out_name, in_name])
 
+	await _process_switch_in()
+
+
+func _load_incoming_pokemon() -> void:
+	if spot and in_pokemon:
+		in_pokemon.clear_last_used_move()
+		spot.load_active_pokemon(in_pokemon, rules)
+
+
+func _process_switch_in() -> void:
 	if in_pokemon != null and not in_pokemon.is_fainted():
 		await BattleEffectController.process_phase(in_pokemon, BattleEffect.Phases.ON_SWITCH_IN)
 
+
+func _is_enemy_trainer_send_in() -> bool:
+	return (
+		side != null
+		and side.type == BattleSide.Types.ENEMY
+		and rules != null
+		and rules.type == BattleRules.BattleTypes.TRAINER
+	)
+
+
+func _resolve_trainer_name() -> String:
+	if side == null:
+		return "Entrenador"
+	var names := side.get_trainer_names()
+	if not names.is_empty() and not names[0].is_empty():
+		return names[0]
+	return "Entrenador"

--- a/Scripts/Battle/core/Battle IAs/BattleIA.gd
+++ b/Scripts/Battle/core/Battle IAs/BattleIA.gd
@@ -28,6 +28,50 @@ func decide_action(_pokemon: BattlePokemon) -> BattleChoice:
 	push_error("decide_action() debe ser implementado en la subclase de BattleIA")
 	return BattlePassChoice.new()
 
+## Elige el sustituto tras debilitarse el activo (cambio forzado por KO).
+## Las subclases pueden sobreescribir para estrategia (tipos, matchups, etc.).
+func decide_forced_switch(side: BattleSide, spot: BattleSpot, fainted: BattlePokemon) -> BattleSwitchChoice:
+	return build_first_available_forced_switch(side, spot, fainted)
+
+## Primer Pokémon vivo del party que no esté en campo (orden de lista).
+func build_first_available_forced_switch(
+	side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon
+) -> BattleSwitchChoice:
+	var incoming := find_first_bench_pokemon(side)
+	if incoming == null:
+		return null
+	return _make_forced_switch_choice(side, spot, fainted, incoming)
+
+
+func find_first_bench_pokemon(side: BattleSide) -> BattlePokemon:
+	if side == null:
+		return null
+	for p in side.pokemonParty:
+		if p != null and not p.is_fainted() and not p.in_battle:
+			return p
+	return null
+
+
+func _make_forced_switch_choice(
+	side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon,
+	incoming: BattlePokemon
+) -> BattleSwitchChoice:
+	var choice := BattleSwitchChoice.new()
+	choice.side = side
+	choice.target_spot = spot
+	choice.outgoing_pokemon = fainted
+	choice.incoming_pokemon = incoming
+	choice.pokemon = incoming
+	choice.forced_by_faint = true
+	if spot != null:
+		choice.origin_spot_index = spot.index
+	choice.target_index = side.pokemonParty.find(incoming)
+	return choice
+
 # ============================================================================
 # MÉTODOS DE UTILIDAD COMUNES PARA TODAS LAS IAS
 # ============================================================================

--- a/Scripts/Battle/core/Battle IAs/BattleIA_Easy.gd
+++ b/Scripts/Battle/core/Battle IAs/BattleIA_Easy.gd
@@ -52,7 +52,11 @@ func decide_action(pokemon: BattlePokemon) -> BattleChoice:
 	
 	return choice
 
-## Selecciona un movimiento aleatorio como fallback.
+## Tras KO del activo: primer Pokémon vivo del party que no esté en campo.
+func decide_forced_switch(side: BattleSide, spot: BattleSpot, fainted: BattlePokemon) -> BattleSwitchChoice:
+	return build_first_available_forced_switch(side, spot, fainted)
+
+
 func _select_random_move(
 	pokemon: BattlePokemon,
 	moves: Array[BattleMove],

--- a/Scripts/Battle/core/Controllers/BattleController.gd
+++ b/Scripts/Battle/core/Controllers/BattleController.gd
@@ -87,6 +87,20 @@ func assign_active_pokemons_to_spots():
 
 	# Ajustar visualmente la posición de los spots
 	ui.position_battlespots_for_mode(rules.mode)
+	prepare_trainer_intro_field()
+
+
+func prepare_trainer_intro_field() -> void:
+	if rules == null or rules.type != BattleRules.BattleTypes.TRAINER:
+		return
+	if enemy_side == null:
+		return
+	for spot: BattleSpot in enemy_side.battle_spots:
+		if spot == null:
+			continue
+		spot.set_pokemon_sprite_visible(false)
+		if spot.hp_bar:
+			spot.hp_bar.visible = false
 
 
 func _connect_exp_signals_on_spots(spots: Array[BattleSpot]) -> void:

--- a/Scripts/Battle/core/Controllers/BattleTurnController.gd
+++ b/Scripts/Battle/core/Controllers/BattleTurnController.gd
@@ -350,8 +350,69 @@ func _resolve_faint_on_spot(
 ) -> void:
 	if spot == null or spot.pokemon == null or not spot.pokemon.is_fainted():
 		return
+	var fainted := spot.pokemon
+	var side := fainted.side
 	await spot.play_faint_animation()
-	await battle_controller.ui.show_faint_message(spot.pokemon)
+	await battle_controller.ui.show_faint_message(fainted)
 	if grant_exp:
-		await battle_controller.grant_experience_after_enemy_ko(spot.pokemon, exp_executor)
+		await battle_controller.grant_experience_after_enemy_ko(fainted, exp_executor)
+	BattleEffectController.clear_pokemon_effects(fainted)
 	spot.remove_pokemon()
+
+	if battle_controller.battle_finished():
+		return
+	if side == null or not side.has_any_pokemon_alive():
+		return
+	if spot.pokemon != null:
+		return
+
+	await _send_forced_switch_after_faint(side, spot, fainted)
+
+
+func _send_forced_switch_after_faint(
+	side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon
+) -> void:
+	var choice: BattleSwitchChoice = null
+	if side.is_controllable():
+		choice = await battle_controller.ui.resolve_player_forced_switch_after_faint(side, spot, fainted)
+		if battle_controller.battle_finished():
+			return
+	else:
+		var participant := _get_side_participant(side)
+		if participant != null:
+			choice = participant.decide_forced_switch_for(side, spot, fainted)
+			if choice != null and _is_trainer_send_in_after_faint(side):
+				await battle_controller.ui.handle_opponent_trainer_send_in_sequence(
+					side, participant, choice
+				)
+				if battle_controller.battle_finished():
+					return
+
+	if choice == null:
+		if side.escapedBattle or battle_controller.battle_finished():
+			return
+		push_warning("Forced switch: no se pudo elegir sustituto.")
+		return
+
+	var handlers := choice.resolve()
+	if handlers.is_empty():
+		push_warning("Forced switch: no se pudo resolver el cambio.")
+		return
+	await handle_switch_result(choice, handlers)
+
+
+func _get_side_participant(side: BattleSide) -> BattleParticipant:
+	if side == null or side.participants.is_empty():
+		return null
+	return side.participants[0]
+
+
+func _is_trainer_send_in_after_faint(side: BattleSide) -> bool:
+	if side == null or side.is_controllable():
+		return false
+	var rules := side.battle_rules
+	if rules == null and battle_controller != null:
+		rules = battle_controller.rules
+	return rules != null and rules.type == BattleRules.BattleTypes.TRAINER

--- a/Scripts/Battle/core/Handlers/BattleDamageAilmentMoveHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattleDamageAilmentMoveHandler.gd
@@ -14,13 +14,7 @@ func _apply() -> void:
 	damage = move.calculate_damage(defender)
 	show_effectiveness = (damage.effectiveness != 1.0)
 	damage.apply()
-
 	_apply_results.clear()
-	if damage != null and not damage.is_ineffective() and not defender.is_fainted():
-		for entry in move.get_ailment_entries():
-			_apply_results.append(_try_apply_ailment_entry(entry))
-
-	_finalize_defender_move_resolution(damage)
 
 
 func _visualize(ui) -> void:
@@ -30,6 +24,13 @@ func _visualize(ui) -> void:
 			await ui.show_critical_hit_message()
 		if show_effectiveness:
 			await ui.show_effectiveness_message(damage)
+
+		_finalize_defender_move_resolution(damage)
+
+		var defender: BattlePokemon = target.get_pokemon().get_active_battle_pokemon() if target.get_pokemon() != null else null
+		if defender != null and not damage.is_ineffective() and not defender.is_fainted():
+			for entry in move.get_ailment_entries():
+				_apply_results.append(_try_apply_ailment_entry(entry))
 
 	for apply_data in _apply_results:
 		await _visualize_ailment_entry_result(ui, apply_data, false)

--- a/Scripts/Battle/core/Participants/BattleParticipant.gd
+++ b/Scripts/Battle/core/Participants/BattleParticipant.gd
@@ -58,5 +58,15 @@ func decide_action_for(pokemon: BattlePokemon) -> BattleChoice:
 	return await pokemon.decide_random_action()  # fallback aleatorio
 
 
+func decide_forced_switch_for(
+	battle_side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon
+) -> BattleSwitchChoice:
+	if ai_controller:
+		return ai_controller.decide_forced_switch(battle_side, spot, fainted)
+	return BattleIA.new().build_first_available_forced_switch(battle_side, spot, fainted)
+
+
 func get_active_pokemons() -> Array[BattlePokemon]:
 	return pokemon_team.filter(func(pk): return pk.in_battle and not pk.fainted)

--- a/Scripts/Battle/ui/BattleMessageController.gd
+++ b/Scripts/Battle/ui/BattleMessageController.gd
@@ -52,11 +52,9 @@ func get_intro_messages(
 					"text": "¡" + enemy + " quiere luchar!",
 					"showIconAtEnd": true
 				})
-				messages.append({
-					"type": "display",
-					"text": "¡" + enemy + " envió a " + enemy_pokemon[0].get_name() + "!",
-					"wait_time": 1.2
-				})
+				messages.append(get_trainer_send_in_intro_message(
+					enemy_pokemon[0].get_display_name(), enemy, 0
+				))
 			messages.append({
 				"type": "display",
 				"text": "¡Adelante, " + player_pokemon[0].get_name() + "!",
@@ -77,22 +75,23 @@ func get_intro_messages(
 						"text": "¡" + enemy_trainers[0] + " quiere luchar!",
 						"showIconAtEnd": true
 					})
-					messages.append({
-						"type": "display",
-						"text": "¡" + enemy_trainers[0] + " envió a " + enemy_pokemon[0].get_name() + " y " + enemy_pokemon[1].get_name() + "!",
-						"wait_time": 1.4
-					})
+					messages.append(get_trainer_double_send_in_intro_message(
+						enemy_pokemon[0].get_display_name(),
+						enemy_pokemon[1].get_display_name(),
+						enemy_trainers[0]
+					))
 				elif enemy_trainers.size() == 2:
 					messages.append({
 						"type": "input",
 						"text": "¡" + enemy_trainers[0] + " y " + enemy_trainers[1] + " quieren luchar!",
 						"showIconAtEnd": true
 					})
-					messages.append({
-						"type": "display",
-						"text": "¡" + enemy_trainers[0] + " y " + enemy_trainers[1] + " enviaron a " + enemy_pokemon[0].get_name() + " y " + enemy_pokemon[1].get_name() + "!",
-						"wait_time": 1.4
-					})
+					messages.append(get_trainer_send_in_intro_message(
+						enemy_pokemon[0].get_display_name(), enemy_trainers[0], 0
+					))
+					messages.append(get_trainer_send_in_intro_message(
+						enemy_pokemon[1].get_display_name(), enemy_trainers[1], 1
+					))
 
 			if player_trainers.size() == 1:
 				messages.append({
@@ -400,6 +399,68 @@ func get_faint_message(pokemon: BattlePokemon) -> Dictionary:
 		"text": "¡%s se debilitó!" % pokemon.get_battle_display_name(true), #Validado HGSS
 		"showIconAtEnd": true
 	}
+
+
+func get_use_next_pokemon_prompt_text() -> String:
+	return "¿Usas el siguiente Pokémon?"
+
+
+func get_faint_refuse_flee_failed_message() -> Dictionary:
+	return {
+		"type": "input",
+		"text": "¡No puedes huir!",
+		"showIconAtEnd": true
+	}
+
+
+func get_opponent_next_pokemon_message(pokemon_name: String, trainer_name: String) -> Dictionary:
+	return {
+		"type": "input",
+		"text": "¡%s será el próximo POKéMON de %s!" % [pokemon_name, trainer_name],
+		"showIconAtEnd": true
+	}
+
+
+func get_trainer_send_in_display_message(pokemon_name: String, trainer_name: String) -> Dictionary:
+	return {
+		"type": "display",
+		"text": "¡%s es el POKéMON enviado por %s!" % [pokemon_name, trainer_name],
+		"wait_time": 1.2
+	}
+
+
+func get_trainer_send_in_intro_message(
+	pokemon_name: String,
+	trainer_name: String,
+	enemy_spot_index: int
+) -> Dictionary:
+	var msg := get_trainer_send_in_display_message(pokemon_name, trainer_name)
+	msg["trainer_send_in"] = true
+	msg["enemy_spot_index"] = enemy_spot_index
+	return msg
+
+
+func get_trainer_double_send_in_display_message(
+	pokemon_a: String,
+	pokemon_b: String,
+	trainer_name: String
+) -> Dictionary:
+	return {
+		"type": "display",
+		"text": "¡%s y %s son la opción de %s!" % [pokemon_a, pokemon_b, trainer_name],
+		"wait_time": 1.4
+	}
+
+
+func get_trainer_double_send_in_intro_message(
+	pokemon_a: String,
+	pokemon_b: String,
+	trainer_name: String
+) -> Dictionary:
+	var msg := get_trainer_double_send_in_display_message(pokemon_a, pokemon_b, trainer_name)
+	msg["trainer_send_in"] = true
+	msg["trainer_send_in_double"] = true
+	return msg
 
 
 func get_gained_exp_message(battle_pokemon: BattlePokemon, exp_gained: int) -> Dictionary:

--- a/Scripts/Battle/ui/BattlePartySwitchController.gd
+++ b/Scripts/Battle/ui/BattlePartySwitchController.gd
@@ -28,9 +28,14 @@ func get_party_members_ordered() -> Array[Pokemon]:
 	return out
 
 
-func touch_pokemon(_mon: Pokemon) -> void:
-	# No-op: en combate la fuente de verdad es BattlePokemon/base_data ya inicializado.
-	pass
+func touch_pokemon(mon: Pokemon) -> void:
+	if _side == null or mon == null:
+		return
+	for bp in _side.pokemonParty:
+		if bp != null and bp.base_data == mon:
+			var max_hp := mon.get_final_stat(StatsEnum.Values.HP)
+			mon.hp_actual = clampi(bp.get_hp(), 0, max_hp)
+			return
 
 
 func get_slot_view(slot: int) -> Dictionary:
@@ -40,6 +45,7 @@ func get_slot_view(slot: int) -> Dictionary:
 
 	var mon: Pokemon = bp.base_data
 	var max_hp := mon.get_final_stat(StatsEnum.Values.HP)
+	mon.hp_actual = clampi(bp.get_hp(), 0, max_hp)
 	var status := "—"
 	if bp.is_fainted():
 		status = "Debilitado"
@@ -96,10 +102,10 @@ func get_invalid_switch_reason(slot: int) -> String:
 	var candidate: BattlePokemon = get_battle_pokemon_at(slot)
 	if candidate == null:
 		return "No hay ningún Pokémon en ese slot."
-	if candidate == _active_pokemon:
-		return "%s ya está en el campo de batalla." % candidate.get_display_name()
 	if candidate.is_fainted():
 		return "¡A %s no le quedan fuerzas para luchar!" % candidate.get_display_name()
+	if candidate == _active_pokemon:
+		return "%s ya está en el campo de batalla." % candidate.get_display_name()
 	if candidate.in_battle:
 		return "%s ya está en el campo de batalla." % candidate.get_display_name()
 	if not candidate.inBattleParty:

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -599,6 +599,274 @@ func show_switch_selection(pokemon: BattlePokemon) -> BattleChoice:
 		choice.origin_spot_index = pokemon.battle_spot.index
 	return choice
 
+
+func resolve_player_forced_switch_after_faint(
+	side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon
+) -> BattleSwitchChoice:
+	actions_menu.hide()
+	moves_menu.hide()
+	target_selector_ui.hide()
+	message_box.hide()
+
+	var rules: BattleRules = side.battle_rules if side != null else null
+	if rules == null and battle_controller != null:
+		rules = battle_controller.rules
+	var is_wild := rules != null and rules.type == BattleRules.BattleTypes.WILD
+
+	if is_wild:
+		var prompt_idx: int = await DisplayManager.show_message_with_choices(
+			message_controller.get_use_next_pokemon_prompt_text(),
+			["Sí", "No"],
+			true
+		)
+		if prompt_idx != 0:
+			var escaped := await _attempt_battle_flee(fainted, false)
+			if escaped:
+				return null
+			await show_message_from_dict(message_controller.get_faint_refuse_flee_failed_message())
+			await _await_menu_inputs_released()
+
+	return await show_forced_switch_selection(side, spot, fainted)
+
+
+func handle_opponent_trainer_send_in_sequence(
+	_enemy_side: BattleSide,
+	participant: BattleParticipant,
+	incoming_choice: BattleSwitchChoice
+) -> void:
+	var incoming: BattlePokemon = incoming_choice.incoming_pokemon
+	if incoming == null:
+		return
+
+	actions_menu.hide()
+	moves_menu.hide()
+	target_selector_ui.hide()
+	message_box.hide()
+
+	var trainer_name := participant.name if participant != null and not participant.name.is_empty() else "Entrenador"
+	var pokemon_name := incoming.get_display_name()
+	await show_message_from_dict(
+		message_controller.get_opponent_next_pokemon_message(pokemon_name, trainer_name)
+	)
+
+	var player_name := _get_player_battle_name()
+	var switch_idx: int = await DisplayManager.show_message_with_choices(
+		"%s, ¿quieres cambiar de POKéMON?" % player_name,
+		["Sí", "No"],
+		true
+	)
+	if switch_idx != 0:
+		return
+
+	var active := _get_player_active_pokemon()
+	if active == null or battle_controller == null:
+		return
+
+	var player_switch: BattleSwitchChoice = await show_optional_switch_selection(active)
+	if player_switch == null:
+		return
+
+	var handlers := player_switch.resolve()
+	if handlers.is_empty():
+		return
+	await battle_controller.turn_controller.handle_switch_result(player_switch, handlers)
+
+
+func show_optional_switch_selection(pokemon: BattlePokemon) -> BattleSwitchChoice:
+	if party_ui == null:
+		push_error("BattleUI: PartyUI no está disponible en la escena de batalla.")
+		return null
+
+	_sync_player_battle_party_to_persistent()
+	await _await_menu_inputs_released()
+
+	var switch_controller = _BATTLE_PARTY_SWITCH_CONTROLLER.new(pokemon.side, pokemon, false)
+	party_ui.setup(switch_controller)
+	actions_menu.hide()
+	moves_menu.hide()
+	target_selector_ui.hide()
+	message_box.hide()
+
+	var current_slot: int = switch_controller.find_slot_for_battle_pokemon(pokemon)
+	party_ui.open_for_battle_switch_pick(current_slot, false)
+
+	var selection_state := {
+		"selected_slot": -1,
+		"pending_slot": -1,
+		"canceled": false,
+		"done": false,
+		"rejected_message": {},
+	}
+
+	var on_selected := func(slot_index: int) -> void:
+		selection_state["pending_slot"] = slot_index
+	var on_canceled := func() -> void:
+		selection_state["canceled"] = true
+		selection_state["done"] = true
+	var on_rejected := func(message: Dictionary) -> void:
+		selection_state["rejected_message"] = message
+
+	party_ui.battle_switch_slot_selected.connect(on_selected)
+	party_ui.battle_switch_cancelled.connect(on_canceled)
+	party_ui.battle_switch_rejected.connect(on_rejected)
+	while not bool(selection_state["done"]):
+		var pending_slot: int = int(selection_state["pending_slot"])
+		if pending_slot >= 0:
+			selection_state["pending_slot"] = -1
+			var switch_ctx := BattlePhaseContext.for_choice(pokemon, BattleSwitchChoice.new())
+			await BattleEffectController.process_phase(
+				pokemon, BattleEffect.Phases.ON_VALIDATE_SWITCH, switch_ctx
+			)
+			if switch_ctx.rejected:
+				if not switch_ctx.rejection_message.is_empty():
+					await _show_party_switch_rejection_message(switch_ctx.rejection_message)
+				await _await_menu_inputs_released()
+				continue
+			selection_state["selected_slot"] = pending_slot
+			selection_state["done"] = true
+			continue
+		var rejected: Dictionary = selection_state["rejected_message"]
+		if not rejected.is_empty():
+			selection_state["rejected_message"] = {}
+			await _show_party_switch_rejection_message(rejected)
+		await get_tree().process_frame
+
+	if party_ui.battle_switch_slot_selected.is_connected(on_selected):
+		party_ui.battle_switch_slot_selected.disconnect(on_selected)
+	if party_ui.battle_switch_cancelled.is_connected(on_canceled):
+		party_ui.battle_switch_cancelled.disconnect(on_canceled)
+	if party_ui.battle_switch_rejected.is_connected(on_rejected):
+		party_ui.battle_switch_rejected.disconnect(on_rejected)
+
+	party_ui.close()
+
+	if bool(selection_state["canceled"]):
+		return null
+
+	var selected_slot: int = int(selection_state["selected_slot"])
+	var incoming_bp: BattlePokemon = switch_controller.get_battle_pokemon_at(selected_slot)
+	if incoming_bp == null:
+		return null
+
+	var choice := BattleSwitchChoice.new()
+	choice.pokemon = pokemon
+	choice.side = pokemon.side
+	choice.target_index = selected_slot
+	choice.outgoing_pokemon = pokemon
+	choice.incoming_pokemon = incoming_bp
+	if pokemon.battle_spot != null:
+		choice.origin_spot_index = pokemon.battle_spot.index
+	return choice
+
+
+func _get_player_battle_name() -> String:
+	if GameStateService != null:
+		var player_name := str(GameStateService.get_variable("PLAYER_NAME", "PLAYER")).strip_edges()
+		if not player_name.is_empty():
+			return player_name
+	return "PLAYER"
+
+
+func _get_player_active_pokemon() -> BattlePokemon:
+	if battle_controller == null or battle_controller.player_side == null:
+		return null
+	for spot: BattleSpot in battle_controller.player_side.battle_spots:
+		if spot != null and spot.pokemon != null and not spot.pokemon.is_fainted():
+			return spot.pokemon
+	return null
+
+
+func _attempt_battle_flee(runner: BattlePokemon, show_fail_message: bool = true) -> bool:
+	if runner == null or runner.side == null:
+		return false
+	var handler := BattleRunHandler.new(runner, runner.side.battle_rules)
+	handler.apply()
+	var escaped: bool = runner.side.escapedBattle
+	if escaped:
+		await show_escape_message(false, true)
+	elif show_fail_message:
+		await show_escape_message(false, false)
+	return escaped
+
+
+func show_forced_switch_selection(
+	side: BattleSide,
+	spot: BattleSpot,
+	fainted: BattlePokemon
+) -> BattleSwitchChoice:
+	if party_ui == null:
+		push_error("BattleUI: PartyUI no está disponible en la escena de batalla.")
+		return null
+
+	_sync_player_battle_party_to_persistent()
+	await _await_menu_inputs_released()
+
+	var switch_controller = _BATTLE_PARTY_SWITCH_CONTROLLER.new(side, fainted, true)
+	party_ui.setup(switch_controller)
+	actions_menu.hide()
+	moves_menu.hide()
+	target_selector_ui.hide()
+	message_box.hide()
+	party_ui.open_for_battle_switch_pick(-1, true)
+
+	var selection_state := {
+		"selected_slot": -1,
+		"pending_slot": -1,
+		"done": false,
+		"rejected_message": {},
+	}
+
+	var on_selected := func(slot_index: int) -> void:
+		selection_state["pending_slot"] = slot_index
+	var on_rejected := func(message: Dictionary) -> void:
+		selection_state["rejected_message"] = message
+
+	party_ui.battle_switch_slot_selected.connect(on_selected)
+	party_ui.battle_switch_rejected.connect(on_rejected)
+	while not bool(selection_state["done"]):
+		var pending_slot: int = int(selection_state["pending_slot"])
+		if pending_slot >= 0:
+			selection_state["pending_slot"] = -1
+			if not switch_controller.is_selectable_switch_slot(pending_slot):
+				await _await_menu_inputs_released()
+				continue
+			selection_state["selected_slot"] = pending_slot
+			selection_state["done"] = true
+			continue
+		var rejected: Dictionary = selection_state["rejected_message"]
+		if not rejected.is_empty():
+			selection_state["rejected_message"] = {}
+			await _show_party_switch_rejection_message(rejected)
+		await get_tree().process_frame
+
+	if party_ui.battle_switch_slot_selected.is_connected(on_selected):
+		party_ui.battle_switch_slot_selected.disconnect(on_selected)
+	if party_ui.battle_switch_rejected.is_connected(on_rejected):
+		party_ui.battle_switch_rejected.disconnect(on_rejected)
+
+	party_ui.close()
+
+	var selected_slot: int = int(selection_state["selected_slot"])
+	if selected_slot < 0:
+		return null
+	var incoming_bp: BattlePokemon = switch_controller.get_battle_pokemon_at(selected_slot)
+	if incoming_bp == null:
+		return null
+
+	var choice := BattleSwitchChoice.new()
+	choice.side = side
+	choice.target_spot = spot
+	choice.target_index = selected_slot
+	choice.outgoing_pokemon = fainted
+	choice.incoming_pokemon = incoming_bp
+	choice.pokemon = incoming_bp
+	choice.forced_by_faint = true
+	if spot != null:
+		choice.origin_spot_index = spot.index
+	return choice
+
 func _show_party_switch_rejection_message(message: Dictionary) -> void:
 	if message == null or message.is_empty():
 		return
@@ -712,10 +980,28 @@ func play_intro_sequence(rules,player_pokemon,enemy_pokemon,player_trainers,enem
 
 	for msg in intro_messages:
 		await show_message_from_dict(msg)
-		print("escrito!")
+		if bool(msg.get("trainer_send_in", false)):
+			if bool(msg.get("trainer_send_in_double", false)):
+				_reveal_enemy_trainer_send_in(0)
+				_reveal_enemy_trainer_send_in(1)
+			else:
+				_reveal_enemy_trainer_send_in(int(msg.get("enemy_spot_index", 0)))
 
-	# Aquí podrías activar el menú o iniciar la siguiente fase del combate
 	actions_menu.show()
+
+
+func _reveal_enemy_trainer_send_in(spot_index: int) -> void:
+	if battle_controller == null or battle_controller.enemy_side == null:
+		return
+	var spots := battle_controller.enemy_side.battle_spots
+	if spot_index < 0 or spot_index >= spots.size():
+		return
+	var spot: BattleSpot = spots[spot_index]
+	if spot == null:
+		return
+	spot.set_pokemon_sprite_visible(true)
+	if spot.hp_bar:
+		spot.hp_bar.visible = true
 
 func show_used_move_message(user: BattlePokemon, move: BattleMove) -> void:
 	await show_message_from_dict(message_controller.get_used_move_message(user, move))
@@ -773,6 +1059,12 @@ func show_escape_message(is_trainer_battle: bool, escape_succeeded: bool) -> voi
 # Mensajes de cambio de Pokémon
 func show_switch_message(trainer_name: String, pokemon_name: String) -> void:
 	await show_message_from_dict(message_controller.get_switch_message(trainer_name, pokemon_name))
+
+
+func show_trainer_send_in_display(trainer_name: String, pokemon_name: String) -> void:
+	await show_message_from_dict(
+		message_controller.get_trainer_send_in_display_message(pokemon_name, trainer_name)
+	)
 
 # Mensaje de final de combate
 func show_battle_end_message(winner_side: String, rules: BattleRules, enemy_participants: Array) -> void:

--- a/Scripts/UI/PartyUI.gd
+++ b/Scripts/UI/PartyUI.gd
@@ -85,7 +85,7 @@ func open_for_battle_switch_pick(initial_focus_slot: int = -1, force_switch: boo
 	_battle_switch_pick_mode = true
 	_battle_force_switch = force_switch
 	if _battle_force_switch:
-		_set_help_text("Elige un Pokémon para continuar.")
+		_set_help_text(_get_battle_switch_default_help_text())
 	else:
 		_set_help_text("Elige el Pokémon al que cambiar.")
 
@@ -185,6 +185,16 @@ func _set_help_text(text: String) -> void:
 		lbl.setText(text)
 	elif lbl is Label:
 		(lbl as Label).text = text
+
+
+func _get_battle_switch_default_help_text() -> String:
+	if _battle_force_switch:
+		return "Elegir un POKéMON."
+	return "Elige el Pokémon al que cambiar."
+
+
+func _reset_battle_switch_help_text() -> void:
+	_set_help_text(_get_battle_switch_default_help_text())
 
 
 func _apply_menu_mode_all_panels() -> void:
@@ -523,7 +533,6 @@ func _on_input_cancel() -> void:
 		return
 	if _battle_switch_pick_mode:
 		if _battle_force_switch:
-			_set_help_text("Debes elegir un Pokémon válido.")
 			return
 		battle_switch_cancelled.emit()
 		return
@@ -540,7 +549,7 @@ func _on_input_start() -> void:
 		return
 	if _battle_switch_pick_mode and _can_handle_party_input():
 		if _battle_force_switch:
-			_set_help_text("Debes elegir un Pokémon válido.")
+			return
 			return
 		battle_switch_cancelled.emit()
 		return
@@ -569,7 +578,7 @@ func _handle_accept_async() -> void:
 	if _battle_switch_pick_mode:
 		if slot == CANCEL_INDEX:
 			if _battle_force_switch:
-				_set_help_text("Debes elegir un Pokémon válido.")
+				return
 			else:
 				battle_switch_cancelled.emit()
 			return
@@ -701,6 +710,7 @@ func _handle_battle_switch_choice_menu(slot: int) -> void:
 		0:
 			if not _controller.is_selectable_switch_slot(slot):
 				battle_switch_rejected.emit(_controller.get_invalid_switch_message(slot))
+				_reset_battle_switch_help_text()
 				return
 			battle_switch_slot_selected.emit(slot)
 			return
@@ -708,10 +718,7 @@ func _handle_battle_switch_choice_menu(slot: int) -> void:
 			await _open_hgss_summary(slot)
 			return
 		_:
-			if _battle_force_switch:
-				_set_help_text("Elige un Pokémon para continuar.")
-			else:
-				_set_help_text("Elige el Pokémon al que cambiar.")
+			_reset_battle_switch_help_text()
 			return
 
 
@@ -740,7 +747,10 @@ func _open_hgss_summary(slot: int) -> void:
 		pokemon_panels[slot].grab_focus()
 	else:
 		_focus_first_occupied_or_salir()
-	_set_help_text("Elige a un Pokémon.")
+	if _battle_switch_pick_mode:
+		_reset_battle_switch_help_text()
+	else:
+		_set_help_text("Elige a un Pokémon.")
 
 
 func _block_player_control() -> void:


### PR DESCRIPTION
## Summary

Implementación del **PBI 735 — Switch al debilitarse el Pokémon activo**, con flujos diferenciados para combates salvajes y de entrenador, mensajes de envío del rival al estilo HGSS, correcciones de Party UI y fix de ailments tras KO.

## Cambios principales

### Cambio forzado tras KO (jugador)

- Tras debilitarse el activo con banca viva, se abre **Party obligatoria** (`force_switch`, sin cancelar).
- Mensaje por defecto: **"Elegir un POKéMON."**
- Al intentar cancelar (B / Start / Salir) **no ocurre nada**; el mensaje no cambia.
- Pokémon debilitado muestra el recuadro rojo correcto (sync `hp_actual` desde `BattlePokemon`).
- Prioridad del mensaje de rechazo: **"¡A X no le quedan fuerzas para luchar!"** antes que "ya está en combate".
- Tras un rechazo o salir del submenú Cambio/Datos/Salir, el texto de ayuda vuelve al mensaje por defecto.

### Combate salvaje vs entrenador

| Situación | Comportamiento |
|-----------|----------------|
| **Salvaje** | *"¿Usas el siguiente Pokémon?"* → **Sí**: Party obligatoria · **No**: intento de huida (misma lógica que HUIR) |
| **Entrenador** | Party obligatoria directamente (sin pregunta previa) |

- Huida exitosa → *"¡Escapaste sin problemas!"* y fin del combate.
- Huida fallida → *"¡No puedes huir!"* → Party obligatoria.

### IA entrenador (KO del rival)

- Hook `BattleIA.decide_forced_switch()`; `BattleIA_Easy`: primer Pokémon vivo del party.
- Mismo pipeline: `BattleSwitchChoice` → `SwitchEffect` → `ON_SWITCH_IN`.

### Secuencia tras KO del rival entrenador

1. *"¡X será el próximo POKéMON de Entrenador!"* (input)
2. *"PLAYER, ¿quieres cambiar de POKéMON?"* → **Sí**: Party opcional · **No**: continúa
3. Envío del sustituto rival

### Mensajes de envío del entrenador rival

- **1vs1:** *"¡X es el POKéMON enviado por Entrenador!"*
- **Doble (1 entrenador):** *"¡X y Y son la opción de Entrenador!"*
- **Doble (2 entrenadores):** un mensaje por entrenador (formato individual)
- Aplica en **intro del combate** y en **cambios en combate** (incl. KO).
- Orden: **mensaje completo → sprite** (tipo `display`, sin input).

### Ailments + daño

- Los ailments de movimientos con daño (p. ej. Ascuas → quemadura) **no se aplican** si el objetivo queda debilitado por ese mismo golpe.

### Limpieza común

- Efectos persistentes del Pokémon caído se limpian al salir del campo.
- Si no quedan vivos en el party → fin de combate (`count_alive_pokemons()`).

## TestBattle

Escenarios exportables en `TestBattle.tscn`:

| Flag | Escenario |
|------|-----------|
| `use_forced_switch_player_test` | Salvaje: Rattata Nv.20 + Bulbasaur vs Pidgey Nv.8 |
| `use_forced_switch_trainer_test` | Entrenador: Charmander + Squirtle vs Rattata + Bulbasaur (IA Easy) |

## Archivos tocados (principales)

- `Scripts/Battle/core/Controllers/BattleTurnController.gd`
- `Scripts/Battle/ui/BattleUI.gd`
- `Scripts/Battle/ui/BattleMessageController.gd`
- `Scripts/Battle/core/Battle Choices/BattleSwitchChoice.gd`
- `Scripts/Battle/core/Battle Effects/Immediate/SwitchEffect.gd`
- `Scripts/Battle/core/Handlers/BattleSwitchHandler.gd`
- `Scripts/Battle/core/Handlers/BattleDamageAilmentMoveHandler.gd`
- `Scripts/Battle/core/Battle IAs/BattleIA.gd`
- `Scripts/Battle/core/Battle IAs/BattleIA_Easy.gd`
- `Scripts/Battle/core/Participants/BattleParticipant.gd`
- `Scripts/Battle/ui/BattlePartySwitchController.gd`
- `Scripts/UI/PartyUI.gd`
- `Scripts/Battle/core/Controllers/BattleController.gd`
- `Scripts/Battle/Battle.gd`
- `Scripts/Battle/TestBattle.gd`
- `Scenes/Battle/TestBattle.tscn`