### PR TITLE
PBIs: Separación check precisión/resultado por target y mensajes por HitResult (AB#423, AB#687)

### DIFF
--- a/Resources/Actor Styles/Red.tres
+++ b/Resources/Actor Styles/Red.tres
@@ -45,7 +45,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_vxp23")
 }],
-"loop": false,
+"loop": 0,
 "name": &"default",
 "speed": 15.0
 }]
@@ -68,7 +68,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_3drw2")
 }],
-"loop": false,
+"loop": 0,
 "name": &"default",
 "speed": 10.0
 }]
@@ -154,7 +154,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_vahkr")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_left",
 "speed": 15.0
 }, {
@@ -165,7 +165,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_jahj8")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_right",
 "speed": 15.0
 }, {
@@ -182,7 +182,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_tsrlx")
 }],
-"loop": false,
+"loop": 0,
 "name": &"idle",
 "speed": 7.5
 }, {
@@ -193,7 +193,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_hvgyn")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_left",
 "speed": 15.0
 }, {
@@ -204,7 +204,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_l63d1")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_right",
 "speed": 15.0
 }, {
@@ -215,7 +215,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_3ycc4")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_left",
 "speed": 15.0
 }, {
@@ -226,7 +226,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_3ycc4")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_right",
 "speed": 15.0
 }, {
@@ -237,7 +237,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_c7wld")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_left",
 "speed": 15.0
 }, {
@@ -248,7 +248,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_c7wld")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_right",
 "speed": 15.0
 }]
@@ -358,7 +358,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_hoo8s")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_left",
 "speed": 1.0
 }, {
@@ -369,7 +369,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_hoo8s")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_right",
 "speed": 1.0
 }, {
@@ -380,7 +380,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_sdvoe")
 }],
-"loop": true,
+"loop": 1,
 "name": &"idle_down",
 "speed": 1.0
 }, {
@@ -391,7 +391,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_w307e")
 }],
-"loop": true,
+"loop": 1,
 "name": &"idle_left",
 "speed": 1.0
 }, {
@@ -402,7 +402,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_gqdhp")
 }],
-"loop": true,
+"loop": 1,
 "name": &"idle_right",
 "speed": 1.0
 }, {
@@ -413,7 +413,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_nm6ay")
 }],
-"loop": true,
+"loop": 1,
 "name": &"idle_up",
 "speed": 1.0
 }, {
@@ -424,7 +424,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_pgvfc")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_left",
 "speed": 1.0
 }, {
@@ -435,7 +435,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_pgvfc")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_right",
 "speed": 1.0
 }, {
@@ -446,7 +446,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_omyud")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_left",
 "speed": 1.0
 }, {
@@ -457,7 +457,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_omyud")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_right",
 "speed": 1.0
 }, {
@@ -468,7 +468,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_bjirs")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_down_left",
 "speed": 1.0
 }, {
@@ -479,7 +479,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_bjirs")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_down_right",
 "speed": 1.0
 }, {
@@ -490,7 +490,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_jhbin")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_left_left",
 "speed": 1.0
 }, {
@@ -501,7 +501,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_jhbin")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_left_right",
 "speed": 1.0
 }, {
@@ -512,7 +512,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_ajk5k")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_right_left",
 "speed": 1.0
 }, {
@@ -523,7 +523,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_ajk5k")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_right_right",
 "speed": 1.0
 }, {
@@ -534,7 +534,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_duhiy")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_up_left",
 "speed": 1.0
 }, {
@@ -545,7 +545,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_duhiy")
 }],
-"loop": false,
+"loop": 0,
 "name": &"run_up_right",
 "speed": 1.0
 }, {
@@ -556,7 +556,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_7fc7g")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_left",
 "speed": 1.0
 }, {
@@ -567,7 +567,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_7fc7g")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_right",
 "speed": 1.0
 }]
@@ -603,7 +603,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_o3eld")
 }],
-"loop": true,
+"loop": 1,
 "name": &"default",
 "speed": 5.0
 }]
@@ -681,7 +681,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_theat")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_left",
 "speed": 7.5
 }, {
@@ -692,7 +692,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_0hlcb")
 }],
-"loop": false,
+"loop": 0,
 "name": &"down_right",
 "speed": 7.5
 }, {
@@ -709,7 +709,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_tsrlx")
 }],
-"loop": false,
+"loop": 0,
 "name": &"idle",
 "speed": 7.5
 }, {
@@ -720,7 +720,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_6py5t")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_left",
 "speed": 7.5
 }, {
@@ -731,7 +731,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_axjsp")
 }],
-"loop": false,
+"loop": 0,
 "name": &"left_right",
 "speed": 7.5
 }, {
@@ -742,7 +742,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_tj8xc")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_left",
 "speed": 7.5
 }, {
@@ -753,7 +753,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_b34u2")
 }],
-"loop": false,
+"loop": 0,
 "name": &"right_right",
 "speed": 7.5
 }, {
@@ -764,7 +764,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_grd1l")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_left",
 "speed": 7.5
 }, {
@@ -775,7 +775,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_p0ptx")
 }],
-"loop": false,
+"loop": 0,
 "name": &"up_right",
 "speed": 7.5
 }]

--- a/Resources/Animations/Overworld/exit_arrow.tres
+++ b/Resources/Animations/Overworld/exit_arrow.tres
@@ -43,7 +43,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_l5avm")
 }],
-"loop": true,
+"loop": 1,
 "name": &"arrow_down",
 "speed": 2.0
 }, {
@@ -54,7 +54,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_jbt41")
 }],
-"loop": true,
+"loop": 1,
 "name": &"arrow_left",
 "speed": 2.0
 }, {
@@ -65,7 +65,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_g3x3j")
 }],
-"loop": true,
+"loop": 1,
 "name": &"arrow_right",
 "speed": 2.0
 }, {
@@ -76,7 +76,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_tbmlj")
 }],
-"loop": true,
+"loop": 1,
 "name": &"arrow_up",
 "speed": 2.0
 }]

--- a/Resources/Animations/Overworld/trainer_exclamation.tres
+++ b/Resources/Animations/Overworld/trainer_exclamation.tres
@@ -26,7 +26,7 @@ animations = [{
 "duration": 1.0,
 "texture": SubResource("AtlasTexture_kqg7f")
 }],
-"loop": false,
+"loop": 0,
 "name": &"default",
 "speed": 5.0
 }]

--- a/Scenes/Battle/TestBattle.tscn
+++ b/Scenes/Battle/TestBattle.tscn
@@ -6,13 +6,8 @@
 
 [node name="TestBattle" type="Node2D" unique_id=764670732]
 script = ExtResource("1_tse6d")
-use_forced_switch_player_test = false
-use_forced_switch_trainer_test = false
-use_fixed_substitute_test = false
-use_fixed_rattata_vs_gastly = true
-debug_rattata_extended_volatiles = true
 debug_rattata_test_bite = false
-debug_zero_pp = false
+use_move_fail_no_target_test = true
 
 [node name="Player" type="Node" parent="." unique_id=1369444140]
 script = ExtResource("3_bfl41")

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -23,6 +23,12 @@ const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 ## Desactivar para el escenario Sustituto/Anulación (Forcejeo vía Anulación, no por PP).
 @export var debug_zero_pp: bool = false
 
+@export_group("Debug mensajes MOVE_FAIL (PBI 687)")
+## Escenario natural Machop vs Gastly (inmunidad, protección, evasión, fallo de precisión).
+@export var use_move_fail_message_test: bool = false
+## Escenario doble Pikachu+Machop vs Gastly débil + Rattata (sin objetivo al aplicar).
+@export var use_move_fail_no_target_test: bool = false
+
 @export_group("Debug efectos persistentes")
 ## Al iniciar combate: lluvia activa, Reflejo en el lado del jugador y veneno en el primer activo.
 ## Sirve para probar el orden de mensajes al final del turno (Reflejo → Lluvia → Veneno).
@@ -47,6 +53,16 @@ var _bootstrapped_display_manager: DisplayManager = null
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	if not await _ensure_display_manager():
+		return
+	if use_move_fail_no_target_test:
+		_setup_move_fail_no_target_test_parties()
+		_print_move_fail_no_target_test_guide()
+		await wildMoveFailNoTargetTestBattle()
+		return
+	if use_move_fail_message_test:
+		_setup_move_fail_message_test_parties()
+		_print_move_fail_message_test_guide()
+		await wildMoveFailMessageTestBattle()
 		return
 	if use_forced_switch_player_test:
 		_setup_forced_switch_player_test_parties()
@@ -171,6 +187,158 @@ func wildDoubleBattle():
 
 	var winner = await _start_test_battle(participants, rules)
 	print(">>> Batalla terminada. Ganador: %s" % winner)
+
+func wildMoveFailMessageTestBattle() -> void:
+	_setup_move_fail_message_test_parties()
+	var player_participant: BattleParticipant = _create_fixed_player_participant()
+	if wildPokemons == null or wildPokemons.party.is_empty():
+		push_error("TestBattle: wildMoveFailMessageTestBattle sin rival en WildPokemons.")
+		return
+	var wild_bp: BattlePokemon = wildPokemons.party[0].to_battle_pokemon()
+	wild_bp.is_wild = true
+	var test_ia := BattleIA_MoveFailTest.create_gastly_scenario()
+	wild_bp.setIA(test_ia)
+	var wild_participant: BattleParticipantWild = BattleParticipantWild.new([wild_bp])
+	wild_participant.ai_controller = test_ia
+	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.SINGLE)
+	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla MOVE_FAIL (1v1) terminada. Ganador: %s" % winner)
+
+
+func wildMoveFailNoTargetTestBattle() -> void:
+	_setup_move_fail_no_target_test_parties()
+	var player_participant: BattleParticipant = _create_move_fail_no_target_player_participant()
+	if wildPokemons == null or wildPokemons.party.size() < 2:
+		push_error("TestBattle: wildMoveFailNoTargetTestBattle necesita 2 rivales en WildPokemons.")
+		return
+	var wild_team: Array[BattlePokemon] = []
+	for p: Pokemon in wildPokemons.party:
+		var wild_bp: BattlePokemon = p.to_battle_pokemon()
+		wild_bp.is_wild = true
+		wild_team.append(wild_bp)
+	var wild_participant: BattleParticipant = BattleParticipantWild.new(wild_team)
+	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.DOUBLE)
+	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla MOVE_FAIL (NO_TARGET) terminada. Ganador: %s" % winner)
+
+
+func _setup_move_fail_message_test_parties() -> void:
+	if player != null:
+		player.party.clear()
+		player.add_pokemon_to_party(_create_move_fail_test_player_instance())
+	if wildPokemons != null:
+		wildPokemons.party.clear()
+		wildPokemons.add_pokemon_to_party(_create_move_fail_test_enemy_instance())
+
+
+func _setup_move_fail_no_target_test_parties() -> void:
+	if player != null:
+		player.party.clear()
+		player.add_pokemon_to_party(_create_move_fail_no_target_pikachu())
+		player.add_pokemon_to_party(_create_move_fail_no_target_machop())
+	if wildPokemons != null:
+		wildPokemons.party.clear()
+		wildPokemons.add_pokemon_to_party(_create_move_fail_no_target_enemy())
+		wildPokemons.add_pokemon_to_party(_create_move_fail_no_target_decoy_enemy())
+
+
+func _create_move_fail_test_player_instance() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.MACHOP as PokemonsEnum.Values
+	pkmn.level = 30
+	pkmn.is_wild = false
+	pkmn.custom_move_ids = [
+		MovesEnum.Values.TACKLE,
+		MovesEnum.Values.HYPNOSIS,
+	]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_test_enemy_instance() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.GASTLY as PokemonsEnum.Values
+	pkmn.level = 30
+	pkmn.is_wild = true
+	pkmn.custom_move_ids = [
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.LICK,
+		MovesEnum.Values.TAIL_WHIP,
+	]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_no_target_pikachu() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.PIKACHU as PokemonsEnum.Values
+	pkmn.level = 50
+	pkmn.is_wild = false
+	pkmn.custom_move_ids = [MovesEnum.Values.THUNDERBOLT]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_no_target_machop() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.MACHOP as PokemonsEnum.Values
+	pkmn.level = 10
+	pkmn.is_wild = false
+	pkmn.custom_move_ids = [MovesEnum.Values.TACKLE]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_no_target_enemy() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.GASTLY as PokemonsEnum.Values
+	pkmn.level = 5
+	pkmn.is_wild = true
+	pkmn.custom_move_ids = [MovesEnum.Values.LICK]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_no_target_decoy_enemy() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.RATTATA as PokemonsEnum.Values
+	pkmn.level = 30
+	pkmn.is_wild = true
+	pkmn.custom_move_ids = [MovesEnum.Values.TAIL_WHIP]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_move_fail_no_target_player_participant() -> BattleParticipant:
+	var team: Array[BattlePokemon] = []
+	if player == null or player.party.size() < 2:
+		push_error("TestBattle: party insuficiente para NO_TARGET doble.")
+		return BattleParticipant.new(team)
+	for p: Pokemon in player.party:
+		team.append(p.to_battle_pokemon())
+	var participant := BattleParticipant.new(team)
+	participant.is_player = true
+	participant.name = "Jugador"
+	return participant
+
+
+func _print_move_fail_message_test_guide() -> void:
+	print(">>> [MOVE_FAIL 1v1] Machop vs Gastly — casos naturales (IA de prueba en rival)")
+	print(">>> Turno 1 — IMMUNE: Machop Placaje / Gastly Lengüetazo → «No afecta a Gastly...»")
+	print(">>> Turnos 2-7 — EVADED: Machop Hipnosis / Gastly Doble Equipo (×6) → «¡Gastly esquivó el ataque!»")
+	print(">>>        (Hipnosis es estado y sí afecta a Fantasma; Placaje siempre daría inmunidad)")
+	print(">>> Turno 8+ — MISS_GLOBAL: Machop Hipnosis → repite hasta «¡El ataque de Machop falló!»")
+	print(">>> NO_TARGET: activa use_move_fail_no_target_test y relanza F6.")
+
+
+func _print_move_fail_no_target_test_guide() -> void:
+	print(">>> [MOVE_FAIL doble] Pikachu + Machop vs Gastly Nv.5 + Rattata — NO_TARGET natural")
+	print(">>> Turno 1: Pikachu → Rayo / Machop → Placaje (ambos apuntando a Gastly)")
+	print(">>> Pikachu actúa primero (más rápido), debilita a Gastly. Rattata sigue en pie.")
+	print(">>> Machop intenta Placaje al Gastly debilitado → «¡Pero no hay objetivo al que atacar!»")
+
 
 func wildFixedRattataGastlyBattle() -> void:
 	_setup_fixed_rattata_gastly_parties()

--- a/Scripts/Battle/core/Battle Choices/BattleMoveChoice.gd
+++ b/Scripts/Battle/core/Battle Choices/BattleMoveChoice.gd
@@ -19,30 +19,53 @@ func get_priority() -> int:
 ## Resuelve el movimiento y genera los handlers correspondientes
 func resolve() -> Array[BattleHandler]:
 	var handlers: Array[BattleHandler] = []
-	
+
 	var move_instance := get_move()
 	if not move_instance:
 		return handlers
-	
+
 	if targets.is_empty():
 		return handlers
-	
+
 	var category: BattleMoveCategory = move_instance.get_category() if move_instance.has_method("get_category") else null
 	if not category:
 		print("No category found for move: " + move_instance.get_name())
 		return handlers
-	
+
+	if move_instance.get_accuracy() > 0 and not AccuracyUtils.roll_global_accuracy(move_instance, pokemon):
+		handlers.append(MissHandler.new(pokemon, move_instance))
+		return handlers
 
 	for target in targets:
-		if move_instance.get_accuracy() > 0 and not AccuracyUtils.check_hit(move_instance, pokemon, target.get_pokemon()):
-			handlers.append(MissHandler.new(pokemon))
-			continue
-		
-		var handler := category.create_handler(move_instance, pokemon, target)
-		if handler:
-			handlers.append(handler)
-	
+		var hit_result := AccuracyUtils.check_target_hit(move_instance, pokemon, target)
+		if hit_result == HitResult.Values.HIT:
+			var handler := category.create_handler(move_instance, pokemon, target)
+			if handler:
+				handlers.append(handler)
+		else:
+			var fail_handler := _create_fail_handler(hit_result, move_instance, target)
+			if fail_handler:
+				handlers.append(fail_handler)
+
 	return handlers
+
+
+func _create_fail_handler(
+	hit_result: HitResult.Values,
+	move_instance: BattleMove,
+	target: BattleTarget
+) -> BattleHandler:
+	match hit_result:
+		HitResult.Values.EVADED:
+			return EvadedHandler.new(pokemon, move_instance, target)
+		HitResult.Values.PROTECTED:
+			return ProtectedHandler.new(pokemon, move_instance, target)
+		HitResult.Values.IMMUNE:
+			return ImmuneHandler.new(pokemon, move_instance, target)
+		HitResult.Values.NO_TARGET:
+			return NoTargetHandler.new(pokemon, move_instance)
+		_:
+			return NoTargetHandler.new(pokemon, move_instance)
 
 
 # Retorna el target válido si existe; en caso contrario devuelve null

--- a/Scripts/Battle/core/Battle Effects/Immediate/MissEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/MissEffect.gd
@@ -8,4 +8,4 @@ func apply():
 	pass # no cambia el estado
 
 func visualize(ui: BattleUI):
-	await ui.show_failed_move_message(user)
+	await ui.show_move_fail_message(HitResult.Values.MISS_GLOBAL, user)

--- a/Scripts/Battle/core/Controllers/BattleController.gd
+++ b/Scripts/Battle/core/Controllers/BattleController.gd
@@ -73,21 +73,31 @@ func assign_active_pokemons_to_spots():
 	_connect_exp_signals_on_spots(player_spots)
 	_connect_exp_signals_on_spots(enemy_spots)
 
-	for i in player_actives.size():
-		var spot := player_spots[i]
-		spot.load_active_pokemon(player_actives[i], rules)
-		spot.side = player_side
-		player_side.battle_spots.append(spot)
+	player_side.battle_spots.clear()
+	enemy_side.battle_spots.clear()
 
-	for i in enemy_actives.size():
-		var spot := enemy_spots[i]
-		spot.load_active_pokemon(enemy_actives[i], rules)
-		spot.side = enemy_side
-		enemy_side.battle_spots.append(spot)
+	_assign_actives_to_spots(player_actives, player_spots, player_side)
+	_assign_actives_to_spots(enemy_actives, enemy_spots, enemy_side)
 
-	# Ajustar visualmente la posición de los spots
-	ui.position_battlespots_for_mode(rules.mode)
+	ui.position_battlespots_for_mode(rules.mode, player_actives.size(), enemy_actives.size())
 	prepare_trainer_intro_field()
+
+
+func _assign_actives_to_spots(
+	actives: Array[BattlePokemon],
+	spots: Array[BattleSpot],
+	side: BattleSide
+) -> void:
+	for i in spots.size():
+		var spot := spots[i]
+		if i < actives.size():
+			spot.visible = true
+			spot.load_active_pokemon(actives[i], rules)
+			spot.side = side
+			side.battle_spots.append(spot)
+		else:
+			spot.remove_pokemon()
+			spot.visible = false
 
 
 func prepare_trainer_intro_field() -> void:

--- a/Scripts/Battle/core/Controllers/BattleTurnController.gd
+++ b/Scripts/Battle/core/Controllers/BattleTurnController.gd
@@ -192,7 +192,7 @@ func handle_move_result(choice: BattleMoveChoice, handlers: Array[BattleHandler]
 	for i in handlers.size():
 		var h: BattleHandler = handlers[i]
 		if h is BattleMoveHandler and !h.ensure_valid_single_enemy_target_or_null():
-			h = NoTargetHandler.new(choice.pokemon)
+			h = NoTargetHandler.new(choice.pokemon, choice.get_move())
 			handlers[i] = h
 		h.apply()
 

--- a/Scripts/Battle/core/Handlers/BattleMoveHandler.gd
+++ b/Scripts/Battle/core/Handlers/BattleMoveHandler.gd
@@ -51,6 +51,10 @@ func ensure_valid_single_enemy_target_or_null() -> bool:
 	if not is_single:
 		return true
 
+	if target.selection_type == BattleTarget.TYPE.SELECCIONAR \
+			or target.selection_type == BattleTarget.TYPE.ESPECIFICO:
+		return target.is_valid()
+
 	var tp: BattlePokemon = target.get_pokemon()
 	if tp != null and tp.in_battle and not tp.is_fainted() and tp.battle_spot != null:
 		return true

--- a/Scripts/Battle/core/Handlers/EvadedHandler.gd
+++ b/Scripts/Battle/core/Handlers/EvadedHandler.gd
@@ -1,0 +1,6 @@
+extends MoveFailHandler
+
+class_name EvadedHandler
+
+func _init(_user: BattlePokemon, _move: BattleMove, _target: BattleTarget):
+	super(_user, HitResult.Values.EVADED, _move, _target)

--- a/Scripts/Battle/core/Handlers/EvadedHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/EvadedHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://cnnkkhxan4k4o

--- a/Scripts/Battle/core/Handlers/ImmuneHandler.gd
+++ b/Scripts/Battle/core/Handlers/ImmuneHandler.gd
@@ -1,0 +1,6 @@
+extends MoveFailHandler
+
+class_name ImmuneHandler
+
+func _init(_user: BattlePokemon, _move: BattleMove, _target: BattleTarget):
+	super(_user, HitResult.Values.IMMUNE, _move, _target)

--- a/Scripts/Battle/core/Handlers/ImmuneHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/ImmuneHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://dgfa0yru0ttr2

--- a/Scripts/Battle/core/Handlers/MissHandler.gd
+++ b/Scripts/Battle/core/Handlers/MissHandler.gd
@@ -1,16 +1,6 @@
-extends BattleHandler
+extends MoveFailHandler
 
 class_name MissHandler
 
-var user: BattlePokemon
-
-func _init(_user: BattlePokemon):
-	user = _user
-
-func apply() -> void:
-	pass
-
-func visualize(ui: BattleUI) -> void:
-	await ui.show_failed_move_message(user)
-
-
+func _init(_user: BattlePokemon, _move: BattleMove = null):
+	super(_user, HitResult.Values.MISS_GLOBAL, _move, null)

--- a/Scripts/Battle/core/Handlers/MoveFailHandler.gd
+++ b/Scripts/Battle/core/Handlers/MoveFailHandler.gd
@@ -1,0 +1,25 @@
+extends BattleHandler
+
+class_name MoveFailHandler
+
+var user: BattlePokemon
+var move: BattleMove
+var target: BattleTarget
+var hit_result: HitResult.Values
+
+func _init(
+	_user: BattlePokemon,
+	_hit_result: HitResult.Values,
+	_move: BattleMove = null,
+	_target: BattleTarget = null
+):
+	user = _user
+	hit_result = _hit_result
+	move = _move
+	target = _target
+
+func apply() -> void:
+	pass
+
+func visualize(ui: BattleUI) -> void:
+	await ui.show_move_fail_message(hit_result, user, move, target)

--- a/Scripts/Battle/core/Handlers/MoveFailHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/MoveFailHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://cf1w1dqf57s5s

--- a/Scripts/Battle/core/Handlers/NoTargetHandler.gd
+++ b/Scripts/Battle/core/Handlers/NoTargetHandler.gd
@@ -1,16 +1,6 @@
-extends BattleHandler
+extends MoveFailHandler
 
 class_name NoTargetHandler
 
-var user: BattlePokemon
-
-func _init(_user: BattlePokemon):
-    user = _user
-
-func apply() -> void:
-    pass
-
-func visualize(ui: BattleUI) -> void:
-    await ui.show_no_target_message(user)
-
-
+func _init(_user: BattlePokemon, _move: BattleMove = null):
+	super(_user, HitResult.Values.NO_TARGET, _move, null)

--- a/Scripts/Battle/core/Handlers/ProtectedHandler.gd
+++ b/Scripts/Battle/core/Handlers/ProtectedHandler.gd
@@ -1,0 +1,6 @@
+extends MoveFailHandler
+
+class_name ProtectedHandler
+
+func _init(_user: BattlePokemon, _move: BattleMove, _target: BattleTarget):
+	super(_user, HitResult.Values.PROTECTED, _move, _target)

--- a/Scripts/Battle/core/Handlers/ProtectedHandler.gd.uid
+++ b/Scripts/Battle/core/Handlers/ProtectedHandler.gd.uid
@@ -1,0 +1,1 @@
+uid://bse6ihuann7v5

--- a/Scripts/Battle/core/Messages/BattleMessageMoveFail.gd
+++ b/Scripts/Battle/core/Messages/BattleMessageMoveFail.gd
@@ -1,0 +1,84 @@
+class_name BattleMessageMoveFail
+extends RefCounted
+
+
+func get_move_fail_message(
+	hit_result: HitResult.Values,
+	user: BattlePokemon,
+	_move: BattleMove = null,
+	target: BattleTarget = null
+) -> Dictionary:
+	match hit_result:
+		HitResult.Values.MISS_GLOBAL:
+			return _miss_global_message(user)
+		HitResult.Values.EVADED:
+			return _evaded_message(user, target)
+		HitResult.Values.PROTECTED:
+			return _protected_message(user, target)
+		HitResult.Values.IMMUNE:
+			return _immune_message(user, target)
+		HitResult.Values.NO_TARGET:
+			return _no_target_message(user)
+		_:
+			push_warning("BattleMessageMoveFail: HitResult sin mapeo (%d)" % hit_result)
+			return _generic_fail_message(user)
+
+
+func _miss_global_message(user: BattlePokemon) -> Dictionary:
+	return {
+		"type": "wait",
+		"text": "¡El ataque %s falló!" % user.get_battle_possessive_name(),
+		"wait_time": 1.0,
+		"message_key": "move_fail.miss_global",
+	}
+
+
+func _evaded_message(_user: BattlePokemon, target: BattleTarget) -> Dictionary:
+	var target_pokemon := target.get_pokemon() if target != null else null
+	var target_name := target_pokemon.get_battle_display_name(true) if target_pokemon != null else "el objetivo"
+	return {
+		"type": "wait",
+		"text": "¡%s esquivó el ataque!" % target_name,
+		"wait_time": 1.0,
+		"message_key": "move_fail.evaded",
+	}
+
+
+func _protected_message(_user: BattlePokemon, target: BattleTarget) -> Dictionary:
+	var target_pokemon := target.get_pokemon() if target != null else null
+	var target_name := target_pokemon.get_battle_display_name(true) if target_pokemon != null else "el objetivo"
+	return {
+		"type": "wait",
+		"text": "¡%s se protegió!" % target_name,
+		"wait_time": 1.0,
+		"message_key": "move_fail.protected",
+	}
+
+
+func _immune_message(_user: BattlePokemon, target: BattleTarget) -> Dictionary:
+	var target_pokemon := target.get_pokemon() if target != null else null
+	var target_name := target_pokemon.get_battle_target_name() if target_pokemon != null else "el objetivo"
+	return {
+		"type": "wait",
+		"text": "No afecta %s..." % target_name,
+		"wait_time": 1.0,
+		"message_key": "move_fail.immune",
+	}
+
+
+func _no_target_message(_user: BattlePokemon) -> Dictionary:
+	return {
+		"type": "wait",
+		"text": "¡Pero no hay objetivo al que atacar!",
+		"wait_time": 1.0,
+		"message_key": "move_fail.no_target",
+	}
+
+
+func _generic_fail_message(user: BattlePokemon) -> Dictionary:
+	return {
+		"type": "wait",
+		"text": "¡El ataque %s falló!" % user.get_battle_possessive_name(),
+		"wait_time": 1.0,
+		"message_key": "move_fail.generic",
+	}

--- a/Scripts/Battle/core/Messages/BattleMessageMoveFail.gd.uid
+++ b/Scripts/Battle/core/Messages/BattleMessageMoveFail.gd.uid
@@ -1,0 +1,1 @@
+uid://cbrnfsapfr1hj

--- a/Scripts/Battle/core/Messages/MessageFamily.gd
+++ b/Scripts/Battle/core/Messages/MessageFamily.gd
@@ -6,6 +6,7 @@ enum Values {
 	ABILITY,
 	WEATHER,
 	FIELD_EFFECT,
+	MOVE_FAIL,
 }
 
 

--- a/Scripts/Battle/core/Utils/AccuracyUtils.gd
+++ b/Scripts/Battle/core/Utils/AccuracyUtils.gd
@@ -1,19 +1,45 @@
 class_name AccuracyUtils
 
-static func check_hit(move: BattleMove, user: BattlePokemon, target: BattlePokemon) -> bool:
+## Tirada global de precisión: una sola vez por movimiento.
+## Usa precisión base + modificadores globales del usuario (accuracy stage).
+static func roll_global_accuracy(move: BattleMove, user: BattlePokemon) -> bool:
 	if move.get_id() == MovesEnum.Values.STRUGGLE:
 		return true
-	var base_accuracy = move.get_accuracy()
-	# Movimientos sin precisión (0) siempre impactan: usados para efectos de campo/side
-	if base_accuracy <= 0 or !target:
+	var base_accuracy := move.get_accuracy()
+	if base_accuracy <= 0:
 		return true
-	var acc_mod = get_stage_modifier(user.accuracy_stage)
-	var eva_mod = get_stage_modifier(target.evasion_stage)
-
-	var final_accuracy = base_accuracy * acc_mod / eva_mod
-
+	var acc_mod := get_stage_modifier(user.stat_stages.get_stat(StatsEnum.Values.ACCURACY))
+	var final_accuracy := base_accuracy * acc_mod
 	return randf() * 100.0 < final_accuracy
 
+
+## Resolución individual por target sin repetir la tirada global.
+static func check_target_hit(move: BattleMove, _user: BattlePokemon, target: BattleTarget) -> HitResult.Values:
+	if not target.is_valid():
+		return HitResult.Values.NO_TARGET
+
+	if not target.is_pokemon():
+		return HitResult.Values.HIT
+
+	var target_pokemon := target.get_pokemon()
+	if target_pokemon == null:
+		return HitResult.Values.NO_TARGET
+
+	if _is_target_immune(move, target_pokemon):
+		return HitResult.Values.IMMUNE
+
+	if move.get_accuracy() > 0 and _target_evades(target_pokemon):
+		return HitResult.Values.EVADED
+
+	return HitResult.Values.HIT
+
+
+## Compatibilidad: combina tirada global y evaluación por target.
+static func check_hit(move: BattleMove, user: BattlePokemon, target: BattlePokemon) -> bool:
+	if not roll_global_accuracy(move, user):
+		return false
+	var battle_target := BattleTarget.new(target)
+	return check_target_hit(move, user, battle_target) == HitResult.Values.HIT
 
 
 static func get_stage_modifier(stage: int) -> float:
@@ -22,3 +48,20 @@ static func get_stage_modifier(stage: int) -> float:
 		return (3.0 + stage) / 3.0
 	else:
 		return 3.0 / (3.0 - stage)
+
+
+static func _target_evades(target: BattlePokemon) -> bool:
+	var eva_mod := get_stage_modifier(target.stat_stages.get_stat(StatsEnum.Values.EVASION))
+	if eva_mod <= 1.0:
+		return false
+	return randf() >= (1.0 / eva_mod)
+
+
+static func _is_target_immune(move: BattleMove, target: BattlePokemon) -> bool:
+	if target == null or move.is_status_category():
+		return false
+	if move.get_id() == MovesEnum.Values.STRUGGLE:
+		return false
+	return TypeEffectivenessUtils.get_multiplier(
+		move.get_type(), target.get_type1(), target.get_type2()
+	) == 0.0

--- a/Scripts/Battle/core/Utils/HitResult.gd
+++ b/Scripts/Battle/core/Utils/HitResult.gd
@@ -1,0 +1,10 @@
+class_name HitResult
+
+enum Values {
+	HIT,
+	EVADED,
+	PROTECTED,
+	IMMUNE,
+	NO_TARGET,
+	MISS_GLOBAL,
+}

--- a/Scripts/Battle/core/Utils/HitResult.gd.uid
+++ b/Scripts/Battle/core/Utils/HitResult.gd.uid
@@ -1,0 +1,1 @@
+uid://c53be7p8scnlp

--- a/Scripts/Battle/debug/BattleIA_MoveFailTest.gd
+++ b/Scripts/Battle/debug/BattleIA_MoveFailTest.gd
@@ -1,0 +1,57 @@
+extends BattleIA
+
+class_name BattleIA_MoveFailTest
+
+## IA determinista para TestBattle: secuencia de movimientos que provocan fallos naturales.
+
+var _planned_move_ids: Array[int] = []
+var _step := 0
+
+
+func _init() -> void:
+	difficulty_name = "MoveFailTest"
+	use_items = false
+	can_switch_strategically = false
+
+
+static func create_gastly_scenario() -> BattleIA_MoveFailTest:
+	var ia := BattleIA_MoveFailTest.new()
+	ia._planned_move_ids = [
+		MovesEnum.Values.LICK,
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.DOUBLE_TEAM,
+		MovesEnum.Values.DOUBLE_TEAM,
+	]
+	return ia
+
+
+func decide_action(pokemon: BattlePokemon) -> BattleChoice:
+	var move_id := MovesEnum.Values.LICK
+	if _step < _planned_move_ids.size():
+		move_id = _planned_move_ids[_step]
+	_step += 1
+	return _build_move_choice(pokemon, move_id)
+
+
+func _build_move_choice(pokemon: BattlePokemon, move_id: int) -> BattleChoice:
+	var moves := pokemon.get_available_moves()
+	var move_index := -1
+	for i in moves.size():
+		if moves[i].get_id() == move_id:
+			move_index = i
+			break
+	if move_index < 0:
+		var legal := get_selectable_move_indices(pokemon)
+		if legal.is_empty():
+			return BattlePassChoice.new()
+		move_index = legal[0]
+	var move := moves[move_index]
+	var choice := BattleMoveChoice.new()
+	choice.move_index = move_index
+	choice.pokemon = pokemon
+	var selector := BattleTargetSelector.new()
+	choice.targets = selector.resolve_targets(move, pokemon, null)
+	return choice

--- a/Scripts/Battle/debug/BattleIA_MoveFailTest.gd.uid
+++ b/Scripts/Battle/debug/BattleIA_MoveFailTest.gd.uid
@@ -1,0 +1,1 @@
+uid://c701vj32le5eq

--- a/Scripts/Battle/ui/BattleMessageController.gd
+++ b/Scripts/Battle/ui/BattleMessageController.gd
@@ -6,6 +6,7 @@ var AbilityMessages = BattleMessageAbility.new()
 var WeatherMessages = BattleMessageWeather.new()
 var FieldEffectMessages = BattleMessageFieldEffect.new()
 var ItemMessages = BattleMessageItem.new()
+var MoveFailMessages = BattleMessageMoveFail.new()
 const FAMILY := MessageFamily.Values
 
 func get_intro_messages(
@@ -63,50 +64,92 @@ func get_intro_messages(
 
 		BattleRules.BattleModes.DOUBLE:
 			if rules.type == BattleRules.BattleTypes.WILD:
-				messages.append({
-					"type": "input",
-					"text": "¡Un " + enemy_pokemon[0].get_name() + " y un " + enemy_pokemon[1].get_name() + " salvajes aparecieron!",
-					"showIconAtEnd": true
-				})
+				messages.append(_get_wild_double_appeared_message(enemy_pokemon))
 			else:
-				if enemy_trainers.size() == 1:
-					messages.append({
-						"type": "input",
-						"text": "¡" + enemy_trainers[0] + " quiere luchar!",
-						"showIconAtEnd": true
-					})
-					messages.append(get_trainer_double_send_in_intro_message(
-						enemy_pokemon[0].get_display_name(),
-						enemy_pokemon[1].get_display_name(),
-						enemy_trainers[0]
-					))
-				elif enemy_trainers.size() == 2:
-					messages.append({
-						"type": "input",
-						"text": "¡" + enemy_trainers[0] + " y " + enemy_trainers[1] + " quieren luchar!",
-						"showIconAtEnd": true
-					})
-					messages.append(get_trainer_send_in_intro_message(
-						enemy_pokemon[0].get_display_name(), enemy_trainers[0], 0
-					))
-					messages.append(get_trainer_send_in_intro_message(
-						enemy_pokemon[1].get_display_name(), enemy_trainers[1], 1
-					))
+				_append_trainer_double_enemy_intro_messages(
+					messages, enemy_pokemon, enemy_trainers
+				)
 
-			if player_trainers.size() == 1:
-				messages.append({
-					"type": "wait",
-					"text": "¡Adelante, " + player_pokemon[0].get_name() + " y " + player_pokemon[1].get_name() + "!",
-					"wait_time": 0.5
-				})
-			elif player_trainers.size() == 2:
-				messages.append({
-					"type": "wait",
-					"text": "¡" + player_trainers[0] + " y " + player_trainers[1] + " enviaron a " + player_pokemon[0].get_name() + " y " + player_pokemon[1].get_name() + "!",
-					"wait_time": 0.5
-				})
+			_append_player_double_send_in_message(
+				messages, player_pokemon, player_trainers
+			)
 
 	return messages
+
+
+func _get_wild_double_appeared_message(enemy_pokemon: Array[BattlePokemon]) -> Dictionary:
+	var text: String
+	if enemy_pokemon.size() >= 2:
+		text = "¡Un %s y un %s salvajes aparecieron!" % [
+			enemy_pokemon[0].get_name(), enemy_pokemon[1].get_name()
+		]
+	else:
+		text = "¡Un %s salvaje apareció!" % enemy_pokemon[0].get_name()
+	return {"type": "input", "text": text, "showIconAtEnd": true}
+
+
+func _append_trainer_double_enemy_intro_messages(
+	messages: Array[Dictionary],
+	enemy_pokemon: Array[BattlePokemon],
+	enemy_trainers: Array[String]
+) -> void:
+	if enemy_trainers.size() == 1:
+		messages.append({
+			"type": "input",
+			"text": "¡" + enemy_trainers[0] + " quiere luchar!",
+			"showIconAtEnd": true
+		})
+		if enemy_pokemon.size() >= 2:
+			messages.append(get_trainer_double_send_in_intro_message(
+				enemy_pokemon[0].get_display_name(),
+				enemy_pokemon[1].get_display_name(),
+				enemy_trainers[0]
+			))
+		else:
+			messages.append(get_trainer_send_in_intro_message(
+				enemy_pokemon[0].get_display_name(), enemy_trainers[0], 0
+			))
+	elif enemy_trainers.size() >= 2:
+		messages.append({
+			"type": "input",
+			"text": "¡" + enemy_trainers[0] + " y " + enemy_trainers[1] + " quieren luchar!",
+			"showIconAtEnd": true
+		})
+		messages.append(get_trainer_send_in_intro_message(
+			enemy_pokemon[0].get_display_name(), enemy_trainers[0], 0
+		))
+		if enemy_pokemon.size() >= 2:
+			messages.append(get_trainer_send_in_intro_message(
+				enemy_pokemon[1].get_display_name(), enemy_trainers[1], 1
+			))
+
+
+func _append_player_double_send_in_message(
+	messages: Array[Dictionary],
+	player_pokemon: Array[BattlePokemon],
+	player_trainers: Array[String]
+) -> void:
+	var pokemon_names := _format_active_pokemon_names(player_pokemon)
+	if player_trainers.size() == 1:
+		messages.append({
+			"type": "wait",
+			"text": "¡Adelante, %s!" % pokemon_names,
+			"wait_time": 0.5
+		})
+	elif player_trainers.size() >= 2:
+		messages.append({
+			"type": "wait",
+			"text": "¡%s y %s enviaron a %s!" % [
+				player_trainers[0], player_trainers[1], pokemon_names
+			],
+			"wait_time": 0.5
+		})
+
+
+func _format_active_pokemon_names(pokemon: Array[BattlePokemon]) -> String:
+	if pokemon.size() >= 2:
+		return "%s y %s" % [pokemon[0].get_name(), pokemon[1].get_name()]
+	return pokemon[0].get_name()
 
 func get_effectiveness_message(result: DamageEffect) -> Dictionary:
 	if result.is_super_effective():
@@ -391,12 +434,33 @@ func get_generic_stat_stage_failed_message(pokemon: BattlePokemon, is_increase: 
 
 # (El bloque duplicado de agregadores por familia fue consolidado en los métodos anteriores)
 
+func get_move_fail_message(
+	hit_result: HitResult.Values,
+	user: BattlePokemon,
+	move: BattleMove = null,
+	target: BattleTarget = null
+) -> Dictionary:
+	if user == null:
+		return {}
+	return MoveFailMessages.get_move_fail_message(hit_result, user, move, target)
+
+
+func get_fail_effect_message(
+	family: MessageFamily.Values,
+	user: BattlePokemon = null,
+	hit_result: int = 0,
+	move: BattleMove = null,
+	target: BattleTarget = null
+) -> Dictionary:
+	match family:
+		FAMILY.MOVE_FAIL:
+			return get_move_fail_message(hit_result, user, move, target)
+		_:
+			return {}
+
+
 func get_failed_move_message(user: BattlePokemon) -> Dictionary:
-	return {
-		"type": "wait",
-		"text": "¡El ataque %s falló!" % [user.get_battle_possessive_name()],
-		"wait_time": 1.0
-	}
+	return get_move_fail_message(HitResult.Values.MISS_GLOBAL, user)
 
 func get_multi_hit_message(num_hits: int) -> Dictionary:
 	return {
@@ -492,11 +556,7 @@ func get_level_up_message(battle_pokemon: BattlePokemon, new_level: int) -> Dict
 
 
 func get_no_target_message(user: BattlePokemon) -> Dictionary:
-	return {
-		"type": "wait",
-		"text": "¡Pero no hay objetivo al que atacar!",
-		"wait_time": 1.0
-	}
+	return get_move_fail_message(HitResult.Values.NO_TARGET, user)
 
 # Mensaje de escape/huida unificado
 func get_escape_message(is_trainer_battle: bool, escape_succeeded: bool) -> Dictionary:

--- a/Scripts/Battle/ui/BattleSpotUI.gd
+++ b/Scripts/Battle/ui/BattleSpotUI.gd
@@ -94,9 +94,12 @@ func remove_pokemon() -> void:
 		pokemon.in_battle = false
 		pokemon.battle_spot = null
 	pokemon = null
+	sprite.texture = null
 	sprite.visible = false
 	shadow.visible = false
-	hp_bar.visible = false
+	if hp_bar:
+		hp_bar.clear_ui()
+		hp_bar.visible = false
 
 func position_hp_bar(mode: int) -> void:
 	match mode:

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -73,18 +73,16 @@ func show_player_pokemon(pokemons: Array[BattlePokemon], rules: BattleRules):
 	# Mostrar el sprite del Pokémon del jugador
 
 func show_enemy_hp_bar(pokemons: Array[BattlePokemon]):
-	if pokemons.size() >= 1:
-		$FieldUI/EnemyBase/PokemonSpotA/HPBar.visible = true
-	if pokemons.size() >= 2:
-		$FieldUI/EnemyBase/PokemonSpotB/HPBar.visible = true
-	# Mostrar la barra de vida del Pokémon enemigo
+	var spot_a: BattleSpot = $FieldUI/EnemyBase/PokemonSpotA
+	var spot_b: BattleSpot = $FieldUI/EnemyBase/PokemonSpotB
+	spot_a.hp_bar.visible = pokemons.size() >= 1 and spot_a.visible
+	spot_b.hp_bar.visible = pokemons.size() >= 2 and spot_b.visible
 
 func show_player_hp_bar(pokemons: Array[BattlePokemon]):
-	if pokemons.size() >= 1:
-		$FieldUI/PlayerBase/PokemonSpotA/HPBar.visible = true
-	if pokemons.size() >= 2:
-		$FieldUI/PlayerBase/PokemonSpotB/HPBar.visible = true
-	# Mostrar la barra de vida del Pokémon del jugador
+	var spot_a: BattleSpot = $FieldUI/PlayerBase/PokemonSpotA
+	var spot_b: BattleSpot = $FieldUI/PlayerBase/PokemonSpotB
+	spot_a.hp_bar.visible = pokemons.size() >= 1 and spot_a.visible
+	spot_b.hp_bar.visible = pokemons.size() >= 2 and spot_b.visible
 
 func get_player_spots_for_mode(mode: int) -> Array[BattleSpot]:
 	return $FieldUI.get_player_spots_for_mode(mode)
@@ -95,8 +93,12 @@ func get_enemy_spots_for_mode(mode: int) -> Array[BattleSpot]:
 func get_all_spots_for_mode(mode: int) -> Array[BattleSpot]:
 	return $FieldUI.get_all_spots_for_mode(mode)
 
-func position_battlespots_for_mode(mode: int) -> void:
-	$FieldUI.position_battlespots_for_mode(mode)
+func position_battlespots_for_mode(
+	mode: int,
+	player_active_count: int = -1,
+	enemy_active_count: int = -1
+) -> void:
+	$FieldUI.position_battlespots_for_mode(mode, player_active_count, enemy_active_count)
 
 func show_action_selection(pokemon: BattlePokemon) -> BattleChoice:
 	# Mostrar panel de acciones: LUCHAR, POKÉMON, MOCHILA, HUIR
@@ -957,7 +959,7 @@ func show_target_selection(user: BattlePokemon, enemies_only: bool = false) -> B
 	if candidates.size() == 1:
 		return candidates[0]
 
-	message_box.hide()
+	message_box.show_clear_text()
 	get_viewport().gui_release_focus()
 	target_selector_ui.show_selection(grid)
 
@@ -1017,7 +1019,35 @@ func show_struggle_recoil_message(pokemon: BattlePokemon) -> void:
 	clear_message_box()
 
 func show_failed_move_message(user: BattlePokemon) -> void:
-	await show_message_from_dict(message_controller.get_failed_move_message(user))
+	await show_move_fail_message(HitResult.Values.MISS_GLOBAL, user)
+
+
+func show_move_fail_message(
+	hit_result: HitResult.Values,
+	user: BattlePokemon,
+	move: BattleMove = null,
+	target: BattleTarget = null
+) -> void:
+	var msg: Dictionary = message_controller.get_move_fail_message(hit_result, user, move, target)
+	if msg.is_empty():
+		msg = message_controller.get_move_fail_message(HitResult.Values.MISS_GLOBAL, user)
+	await show_message_from_dict(msg)
+	clear_message_box()
+
+
+func show_fail_effect_message(
+	family: MessageFamily.Values,
+	user: BattlePokemon = null,
+	hit_result: int = 0,
+	move: BattleMove = null,
+	target: BattleTarget = null
+) -> void:
+	var msg: Dictionary = message_controller.get_fail_effect_message(
+		family, user, hit_result, move, target
+	)
+	if msg.is_empty():
+		msg = message_controller.get_move_fail_message(HitResult.Values.MISS_GLOBAL, user)
+	await show_message_from_dict(msg)
 	clear_message_box()
 
 func show_multi_hit_message(num_hits: int) -> void:
@@ -1033,8 +1063,7 @@ func show_critical_hit_message() -> void:
 	clear_message_box()
 
 func show_no_target_message(user: BattlePokemon) -> void:
-	await show_message_from_dict(message_controller.get_no_target_message(user))
-	clear_message_box()
+	await show_move_fail_message(HitResult.Values.NO_TARGET, user)
 
 func show_heal_message(pokemon: BattlePokemon) -> void:
 	await show_message_from_dict(message_controller.get_heal_message(pokemon))

--- a/Scripts/Battle/ui/FieldUI.gd
+++ b/Scripts/Battle/ui/FieldUI.gd
@@ -34,30 +34,27 @@ func get_enemy_spot(index: int) -> BattleSpot:
 		1: return $EnemyBase/PokemonSpotB
 		_: return null
 
-func position_battlespots_for_mode(mode: int) -> void:
-	var p_base = $PlayerBase
-	var e_base = $EnemyBase
-
+func position_battlespots_for_mode(
+	mode: int,
+	player_active_count: int = -1,
+	enemy_active_count: int = -1
+) -> void:
 	match mode:
 		BattleRules.BattleModes.SINGLE:
-			# Player side
 			$PlayerBase/PokemonSpotA.global_position = $PlayerBase/Positions/SpotA_Single.global_position
-			$PlayerBase/PokemonSpotB.visible = false  # Solo se usa uno en modo SINGLE
+			$PlayerBase/PokemonSpotB.visible = false
 
-			# Enemy side
 			$EnemyBase/PokemonSpotA.global_position = $EnemyBase/Positions/SpotA_Single.global_position
 			$EnemyBase/PokemonSpotB.visible = false
 
 		BattleRules.BattleModes.DOUBLE:
-			# Player side
 			$PlayerBase/PokemonSpotA.global_position = $PlayerBase/Positions/SpotA_Double.global_position
 			$PlayerBase/PokemonSpotB.global_position = $PlayerBase/Positions/SpotB_Double.global_position
-			$PlayerBase/PokemonSpotB.visible = true
+			$PlayerBase/PokemonSpotB.visible = player_active_count != 1
 
-			# Enemy side
 			$EnemyBase/PokemonSpotA.global_position = $EnemyBase/Positions/SpotA_Double.global_position
 			$EnemyBase/PokemonSpotB.global_position = $EnemyBase/Positions/SpotB_Double.global_position
-			$EnemyBase/PokemonSpotB.visible = true
+			$EnemyBase/PokemonSpotB.visible = enemy_active_count != 1
 
 		_:
 			push_warning("Combate no compatible: usando modo SINGLE por defecto")


### PR DESCRIPTION
## Summary

Reestructuración del sistema de impacto/fallo de movimientos en combate (PBI 423) y mensajería contextual por motivo de fallo al estilo HGSS/Gen 4 (PBI 687). La arquitectura separa la tirada global de precisión de la resolución individual por target, con handlers y mensajes tipados por `HitResult`.

---

## PBI 423 — Precisión global y resultado por target

### Nuevo modelo de datos

- **`HitResult`** (`Scripts/Battle/core/Utils/HitResult.gd`): enum tipado con `HIT`, `EVADED`, `PROTECTED`, `IMMUNE`, `NO_TARGET`, `MISS_GLOBAL`.

### Refactor de `AccuracyUtils`

- **`roll_global_accuracy(move, user)`** — una sola tirada de precisión por movimiento (precisión base × stage de precisión del usuario).
- **`check_target_hit(move, user, target)`** — evaluación individual por target sin repetir la tirada global.
- Orden de evaluación por target: `NO_TARGET` → `IMMUNE` → `EVADED` → `HIT`.
- **`check_hit()`** conservado como wrapper de compatibilidad.
- Corrección: lectura de stages vía `user.stat_stages.get_stat(ACCURACY/EVASION)` en lugar de propiedades sueltas no actualizadas.

### Nuevo flujo en `BattleMoveChoice.resolve()`

1. Si falla la tirada global → un solo `MissHandler`; no se evalúan targets.
2. Si pasa → por cada target, `check_target_hit()` y handler correspondiente.
3. Solo en `HIT` se invoca `category.create_handler()`.

### Handlers de fallo

- **`MoveFailHandler`** — base común (`user`, `move`, `target`, `hit_result`).
- **`MissHandler`** — fallo global de precisión (`MISS_GLOBAL`).
- **`EvadedHandler`** — esquiva por evasión (p. ej. Doble Equipo).
- **`ImmuneHandler`** — inmunidad de tipo (efectividad 0).
- **`NoTargetHandler`** — objetivo inválido o ya no disponible.
- **`ProtectedHandler`** — cableado para PBI futuro de Protección (sin lógica de efecto aún).

### Comportamiento en ejecución

- Revalidación en `BattleTurnController` antes de cada `apply()` si un target cae durante el turno.
- Si el objetivo fue elegido explícitamente (`SELECCIONAR` / `ESPECIFICO`) y ya no es válido, no se redirige a otro rival (Gen 4).

---

## PBI 687 — Mensajería contextual de fallo de movimiento

### Nueva familia de mensajes

- **`MessageFamily.MOVE_FAIL`** añadido al sistema de mensajes de combate.

### `BattleMessageMoveFail`

Mapeo `HitResult` → mensaje con `message_key` (preparado para i18n):

| HitResult     | Mensaje                              |
|---------------|--------------------------------------|
| `MISS_GLOBAL` | «¡El ataque de X falló!»             |
| `EVADED`      | «¡X esquivó el ataque!»              |
| `PROTECTED`   | «¡X se protegió!»                    |
| `IMMUNE`      | «No afecta X...»                     |
| `NO_TARGET`   | «¡Pero no hay objetivo al que atacar!» |

### Integración UI

- **`BattleMessageController`**: `get_move_fail_message()`, `get_fail_effect_message()`.
- **`BattleUI`**: `show_move_fail_message()`, `show_fail_effect_message()`.
- Wrappers legacy (`get_failed_move_message`, `show_no_target_message`) delegan al nuevo sistema.
- **`MissEffect`** y **`MoveFailHandler`** usan la API unificada.


## Correcciones colaterales incluidas

- Intro de combate en dobles asimétricos (1v2 / 2v1) sin crash ni mensajes incorrectos.
- Limpieza y ocultación de `BattleSpot` sin Pokémon activo en dobles asimétricos.
- Panel inferior visible (`show_clear_text`) al seleccionar objetivo manualmente.
