### PR TITLE
PBIs: Mejora arquitectura climas, e intgracion climas Rain, Sun, Hail y Sandstorm (AB#688, AB#689, AB#690, AB#691, AB#692)

### DIFF
--- a/Resources/Data/Moves/201 - Tormenta Arena.tres
+++ b/Resources/Data/Moves/201 - Tormenta Arena.tres
@@ -1,8 +1,10 @@
-[gd_resource type="Resource" script_class="MoveData" format=3 uid="uid://djnmfeu3jf0ah"]
+[gd_resource type="Resource" script_class="MoveData" load_steps=6 format=3 uid="uid://djnmfeu3jf0ah"]
 
 [ext_resource type="Resource" path="res://Resources/Move Categories/WholeFieldEffectMoveCategory.tres" id="1_2gmlq"]
 [ext_resource type="Script" uid="uid://cabw2fccq70uo" path="res://Scripts/Resources/Classes/MoveData.gd" id="1_6pebr"]
 [ext_resource type="Resource" uid="uid://dhburvcqxnam0" path="res://Resources/Data/Types/06.tres" id="2_nhjok"]
+[ext_resource type="Script" uid="uid://b6sandmoveeff1" path="res://Scripts/Battle/core/Battle Effects/Immediate/Moves/SandstormMoveEffect.gd" id="4_moveeffect"]
+[ext_resource type="Resource" uid="uid://bcspxmrep6uk7" path="res://Resources/Data/Weather/SANDSTORM.tres" id="5_sand"]
 
 [resource]
 resource_name = "201 - Tormenta Arena"
@@ -10,7 +12,7 @@ script = ExtResource("1_6pebr")
 internal_name = "sandstorm"
 Name = "Tormenta Arena"
 id = 201
-description = "Tormenta de arena que dura cinco turnos y hiere a 
+description = "Tormenta de arena que dura cinco turnos y hiere a
 todos, excepto a los de tipo Roca, Tierra y Acero,
 y aumenta la Defensa Especial de los de tipo Roca."
 type_id = 6
@@ -24,4 +26,7 @@ solar beam's power is halved.
 moonlight, morning sun, and synthesis only heal 1/4 the user's max HP."
 target_id = 12
 meta_category_id = 10
+weather_id = 3
+weather = ExtResource("5_sand")
+move_effect = ExtResource("4_moveeffect")
 category = ExtResource("1_2gmlq")

--- a/Resources/Data/Moves/241 - Día Soleado.tres
+++ b/Resources/Data/Moves/241 - Día Soleado.tres
@@ -1,8 +1,10 @@
-[gd_resource type="Resource" script_class="MoveData" format=3 uid="uid://brbn3d4ht1mwq"]
+[gd_resource type="Resource" script_class="MoveData" load_steps=6 format=3 uid="uid://brbn3d4ht1mwq"]
 
 [ext_resource type="Resource" path="res://Resources/Move Categories/WholeFieldEffectMoveCategory.tres" id="1_1671l"]
 [ext_resource type="Script" uid="uid://cabw2fccq70uo" path="res://Scripts/Resources/Classes/MoveData.gd" id="1_n71yu"]
 [ext_resource type="Resource" uid="uid://d3pw7574qhbn3" path="res://Resources/Data/Types/10.tres" id="2_v003a"]
+[ext_resource type="Script" uid="uid://b8sunnydaymove01" path="res://Scripts/Battle/core/Battle Effects/Immediate/Moves/SunnyDayMoveEffect.gd" id="4_moveeffect"]
+[ext_resource type="Resource" uid="uid://oq3o8uhtgyu5" path="res://Resources/Data/Weather/SUN.tres" id="5_sun"]
 
 [resource]
 resource_name = "241 - Día Soleado"
@@ -42,4 +44,7 @@ Pokémon with dry skin lose 1/8 max HP at the end of each turn.
 Pokémon with solar power have their original Special Attack raised by 50% but lose 1/8 their max HP at the end of each turn."
 target_id = 12
 meta_category_id = 10
+weather_id = 2
+weather = ExtResource("5_sun")
+move_effect = ExtResource("4_moveeffect")
 category = ExtResource("1_1671l")

--- a/Resources/Data/Moves/258 - Granizo.tres
+++ b/Resources/Data/Moves/258 - Granizo.tres
@@ -1,8 +1,10 @@
-[gd_resource type="Resource" script_class="MoveData" format=3 uid="uid://bjw0fma833hrm"]
+[gd_resource type="Resource" script_class="MoveData" load_steps=6 format=3 uid="uid://bjw0fma833hrm"]
 
 [ext_resource type="Resource" path="res://Resources/Move Categories/WholeFieldEffectMoveCategory.tres" id="1_bhpou"]
 [ext_resource type="Script" uid="uid://cabw2fccq70uo" path="res://Scripts/Resources/Classes/MoveData.gd" id="1_n3cn0"]
 [ext_resource type="Resource" uid="uid://ctaiklw776yao" path="res://Resources/Data/Types/15.tres" id="2_cxyvl"]
+[ext_resource type="Script" uid="uid://b7hailmoveeff01" path="res://Scripts/Battle/core/Battle Effects/Immediate/Moves/HailMoveEffect.gd" id="4_moveeffect"]
+[ext_resource type="Resource" uid="uid://cu43plpmlq0n0" path="res://Resources/Data/Weather/HAIL.tres" id="5_hail"]
 
 [resource]
 resource_name = "258 - Granizo"
@@ -27,4 +29,7 @@ moonlight, morning sun, and synthesis heal only 1/4 of the user's max HP.
 Pokémon with snow cloak are exempt from this effect's damage."
 target_id = 12
 meta_category_id = 10
+weather_id = 4
+weather = ExtResource("5_hail")
+move_effect = ExtResource("4_moveeffect")
 category = ExtResource("1_bhpou")

--- a/Resources/Data/Weather/HAIL.tres
+++ b/Resources/Data/Weather/HAIL.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="WeatherData" load_steps=2 format=3 uid="uid://cu43plpmlq0n0"]
+[gd_resource type="Resource" script_class="WeatherData" load_steps=3 format=3 uid="uid://cu43plpmlq0n0"]
 
+[ext_resource type="Script" uid="uid://d4hailweather01" path="res://Scripts/Battle/core/Battle Effects/Persistent/Weather/HailWeatherEffect.gd" id="1_hailfx"]
 [ext_resource type="Script" uid="uid://b5uwuha6ycfob" path="res://Scripts/Resources/Classes/WeatherData.gd" id="1_of541"]
 
 [resource]
@@ -7,4 +8,4 @@ script = ExtResource("1_of541")
 id = 4
 internal_name = "hail"
 display_name = "Granizo"
-metadata/_custom_type_script = "uid://c3ykal5rqqt2m"
+effect = ExtResource("1_hailfx")

--- a/Resources/Data/Weather/SANDSTORM.tres
+++ b/Resources/Data/Weather/SANDSTORM.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="WeatherData" load_steps=2 format=3 uid="uid://bcspxmrep6uk7"]
+[gd_resource type="Resource" script_class="WeatherData" load_steps=3 format=3 uid="uid://bcspxmrep6uk7"]
 
+[ext_resource type="Script" uid="uid://d5sandstormw01" path="res://Scripts/Battle/core/Battle Effects/Persistent/Weather/SandstormWeatherEffect.gd" id="1_sandfx"]
 [ext_resource type="Script" uid="uid://b5uwuha6ycfob" path="res://Scripts/Resources/Classes/WeatherData.gd" id="1_34o1g"]
 
 [resource]
@@ -7,4 +8,4 @@ script = ExtResource("1_34o1g")
 id = 3
 internal_name = "sandstorm"
 display_name = "Tormenta de arena"
-metadata/_custom_type_script = "uid://c3ykal5rqqt2m"
+effect = ExtResource("1_sandfx")

--- a/Resources/Data/Weather/SUN.tres
+++ b/Resources/Data/Weather/SUN.tres
@@ -1,5 +1,6 @@
-[gd_resource type="Resource" script_class="WeatherData" load_steps=2 format=3 uid="uid://oq3o8uhtgyu5"]
+[gd_resource type="Resource" script_class="WeatherData" load_steps=3 format=3 uid="uid://oq3o8uhtgyu5"]
 
+[ext_resource type="Script" uid="uid://d7sunweather001" path="res://Scripts/Battle/core/Battle Effects/Persistent/Weather/SunWeatherEffect.gd" id="1_sunfx"]
 [ext_resource type="Script" uid="uid://b5uwuha6ycfob" path="res://Scripts/Resources/Classes/WeatherData.gd" id="1_xyyiy"]
 
 [resource]
@@ -7,4 +8,4 @@ script = ExtResource("1_xyyiy")
 id = 2
 internal_name = "sun"
 display_name = "Sol"
-metadata/_custom_type_script = "uid://c3ykal5rqqt2m"
+effect = ExtResource("1_sunfx")

--- a/Scenes/Battle/TestBattle.tscn
+++ b/Scenes/Battle/TestBattle.tscn
@@ -7,7 +7,6 @@
 [node name="TestBattle" type="Node2D" unique_id=764670732]
 script = ExtResource("1_tse6d")
 debug_rattata_test_bite = false
-use_move_fail_no_target_test = true
 
 [node name="Player" type="Node" parent="." unique_id=1369444140]
 script = ExtResource("3_bfl41")

--- a/Scripts/Battle/TestBattle.gd
+++ b/Scripts/Battle/TestBattle.gd
@@ -29,6 +29,10 @@ const _DISPLAY_MANAGER_SCENE := preload("res://Managers/DisplayManager.tscn")
 ## Escenario doble Pikachu+Machop vs Gastly débil + Rattata (sin objetivo al aplicar).
 @export var use_move_fail_no_target_test: bool = false
 
+@export_group("Debug clima")
+## 1vs1 salvaje: Squirtle (Granizo + Día Soleado + Pistola Agua + Tormenta Arena) vs Pidgey (Tornado + Placaje).
+@export var use_rain_weather_test: bool = true
+
 @export_group("Debug efectos persistentes")
 ## Al iniciar combate: lluvia activa, Reflejo en el lado del jugador y veneno en el primer activo.
 ## Sirve para probar el orden de mensajes al final del turno (Reflejo → Lluvia → Veneno).
@@ -83,6 +87,11 @@ func _ready() -> void:
 				+ "Desactívalo para probar Anulación → Forcejeo."
 			)
 		await wildFixedSubstituteTestBattle()
+		return
+	if use_rain_weather_test:
+		_seed_test_capture_items()
+		_print_rain_weather_test_guide()
+		await wildRainWeatherTestBattle()
 		return
 	if use_fixed_rattata_vs_gastly:
 		_setup_fixed_rattata_gastly_parties()
@@ -355,6 +364,21 @@ func wildFixedRattataGastlyBattle() -> void:
 	print(">>> Batalla Rattata vs Pidgey terminada. Ganador: %s" % winner)
 
 
+func wildRainWeatherTestBattle() -> void:
+	_setup_rain_weather_test_parties()
+	var player_participant: BattleParticipant = _create_fixed_player_participant()
+	if wildPokemons == null or wildPokemons.party.is_empty():
+		push_error("TestBattle: wildRainWeatherTestBattle sin rival en WildPokemons.")
+		return
+	var wild_bp: BattlePokemon = wildPokemons.party[0].to_battle_pokemon()
+	wild_bp.is_wild = true
+	var wild_participant: BattleParticipant = BattleParticipantWild.new([wild_bp])
+	var rules := BattleRules.new(BattleRules.BattleTypes.WILD, BattleRules.BattleModes.SINGLE)
+	var participants: Array[BattleParticipant] = [player_participant, wild_participant]
+	var winner = await _start_test_battle(participants, rules)
+	print(">>> Batalla clima (Granizo) terminada. Ganador: %s" % winner)
+
+
 func wildFixedSubstituteTestBattle() -> void:
 	_setup_fixed_substitute_test_parties()
 	var player_participant: BattleParticipant = _create_fixed_player_participant()
@@ -474,6 +498,50 @@ func _print_forced_switch_player_guide() -> void:
 	print(">>> Test cambio forzado (jugador): Rattata (Nv.20) + Bulbasaur (Nv.8) vs Pidgey (Nv.8).")
 	print(">>> Deja que el rival debilite al activo → debe abrirse Party obligatoria (sin cancelar).")
 	print(">>> Elige Bulbasaur (o el otro vivo) y comprueba mensaje de entrada + ON_SWITCH_IN.")
+
+
+func _setup_rain_weather_test_parties() -> void:
+	if player != null:
+		player.party.clear()
+		player.add_pokemon_to_party(_create_rain_weather_test_player_instance())
+	if wildPokemons != null:
+		wildPokemons.party.clear()
+		wildPokemons.add_pokemon_to_party(_create_rain_weather_test_enemy_instance())
+
+
+func _create_rain_weather_test_player_instance() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.SQUIRTLE as PokemonsEnum.Values
+	pkmn.level = 30
+	pkmn.is_wild = false
+	pkmn.custom_move_ids = [
+		MovesEnum.Values.HAIL,
+		MovesEnum.Values.SUNNY_DAY,
+		MovesEnum.Values.WATER_GUN,
+		MovesEnum.Values.SANDSTORM,
+	]
+	pkmn._post_init()
+	return pkmn
+
+
+func _create_rain_weather_test_enemy_instance() -> Pokemon:
+	var pkmn := Pokemon.new()
+	pkmn.pokemon_id = PokemonsEnum.Values.PIDGEY as PokemonsEnum.Values
+	pkmn.level = 30
+	pkmn.is_wild = true
+	pkmn.custom_move_ids = [
+		MovesEnum.Values.GUST,
+		MovesEnum.Values.TACKLE,
+	]
+	pkmn._post_init()
+	return pkmn
+
+
+func _print_rain_weather_test_guide() -> void:
+	print(">>> Combate clima: Squirtle (Granizo + Día Soleado + Pistola Agua + Tormenta Arena) vs Pidgey (Tornado + Placaje).")
+	print(">>>   1) Usa Granizo → mensaje de inicio y granizo activo 5 turnos (+ daño residual).")
+	print(">>>   2) Día Soleado reemplaza el clima activo.")
+	print(">>>   3) Al final de cada turno: mensajes ongoing/end del clima correspondiente.")
 
 
 func _setup_fixed_substitute_test_parties() -> void:
@@ -802,9 +870,12 @@ func _seed_test_capture_items() -> void:
 	bag.add_item(4, 10)  # Poké Ball
 	bag.add_item(3, 10)  # Super Ball
 	bag.add_item(2, 10)  # Ultra Ball
-	bag.add_item(17, 10)  # Poción
+	bag.add_item(17, 20)  # Poción
+	bag.add_item(26, 10)  # Superpoción
+	bag.add_item(25, 10)  # Hiperpoción
+	bag.add_item(24, 5)   # Poción Máxima
 	bag.add_item(18, 10)  # Antídoto
-	print("TestBattle: ítems de prueba en mochila (bolas x10, Poción x10, Antídoto x10).")
+	print("TestBattle: ítems de prueba en mochila (bolas x10, pociones, Antídoto x10).")
 
 
 func _create_pokemon_instance(

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/HailMoveEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/HailMoveEffect.gd
@@ -1,0 +1,2 @@
+extends WeatherMoveEffect
+class_name HailMoveEffect

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/HailMoveEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/HailMoveEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://b7hailmoveeff01

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/RainDanceMoveEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/RainDanceMoveEffect.gd
@@ -1,28 +1,2 @@
-extends BattleMoveEffect
+extends WeatherMoveEffect
 class_name RainDanceMoveEffect
-
-var already_active: bool = false
-var weather: WeatherData = null
-
-func _init(_move: BattleMove, _user: BattlePokemon, _target: BattlePokemon = null) -> void:
-	super._init(_move, _user, _target)
-	weather = move.get_weather()
-
-func apply():
-	# Crear efecto de lluvia con duración de 5 turnos
-	# El parámetro 'true' indica que fue iniciado por un movimiento (no es lluvia natural)
-	var effect_instance = weather.get_effect(5, true)
-	
-	# Evitar duplicar clima: si ya está lloviendo, no hacemos nada
-	if BattleEffectController.has_field_effect(effect_instance):
-		already_active = true
-		return
-
-	BattleEffectController.add_field_effect(effect_instance)
-
-func visualize(ui: BattleUI):
-	# Mostrar mensajes según si ya estaba activa la lluvia
-	if already_active:
-		await ui.show_already_effect_message(MessageFamily.Values.WEATHER, null, weather.id)
-		return
-	await ui.show_start_effect_message(MessageFamily.Values.WEATHER, null, weather.id)

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/SandstormMoveEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/SandstormMoveEffect.gd
@@ -1,0 +1,2 @@
+extends WeatherMoveEffect
+class_name SandstormMoveEffect

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/SandstormMoveEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/SandstormMoveEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://b6sandmoveeff1

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/SunnyDayMoveEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/SunnyDayMoveEffect.gd
@@ -1,0 +1,2 @@
+extends WeatherMoveEffect
+class_name SunnyDayMoveEffect

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/SunnyDayMoveEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/SunnyDayMoveEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://b8sunnydaymove01

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/WeatherMoveEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/WeatherMoveEffect.gd
@@ -1,0 +1,32 @@
+class_name WeatherMoveEffect
+extends BattleMoveEffect
+
+var already_active: bool = false
+var weather: WeatherData = null
+
+
+func _init(_move: BattleMove, _user: BattlePokemon, _target: BattlePokemon = null) -> void:
+	super._init(_move, _user, _target)
+	weather = move.get_weather()
+
+
+func apply() -> void:
+	if weather == null:
+		return
+	var effect_instance := weather.get_effect(5, true)
+	if effect_instance == null:
+		return
+	if BattleEffectController.has_field_effect(effect_instance):
+		already_active = true
+		return
+	BattleEffectController.remove_field_weather_effects()
+	BattleEffectController.add_field_effect(effect_instance)
+
+
+func visualize(ui: BattleUI) -> void:
+	if weather == null:
+		return
+	if already_active:
+		await ui.show_already_effect_message(MessageFamily.Values.WEATHER, null, weather.id)
+		return
+	await ui.show_start_effect_message(MessageFamily.Values.WEATHER, null, weather.id)

--- a/Scripts/Battle/core/Battle Effects/Immediate/Moves/WeatherMoveEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Immediate/Moves/WeatherMoveEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://c9weathermove001

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/HailWeatherEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/HailWeatherEffect.gd
@@ -1,0 +1,69 @@
+class_name HailWeatherEffect
+extends WeatherBattleEffect
+
+const MAGIC_GUARD_ABILITY_ID := 98
+const OVERCOAT_ABILITY_ID := 142
+
+var _residual_targets: Array[BattlePokemon] = []
+
+
+func _on_weather_tick(_pokemon: BattlePokemon, phase: Phases, _ctx: BattlePhaseContext = null) -> void:
+	if phase != Phases.ON_END_BATTLE_TURN or has_finished():
+		return
+	_residual_targets.clear()
+	for bp in _get_active_pokemon():
+		if bp.is_fainted() or _is_immune_to_hail(bp):
+			continue
+		var dmg := ceili(bp.total_hp / 16.0)
+		var effect := DamageEffect.new(null, bp, null, dmg)
+		bp.take_damage(effect)
+		_residual_targets.append(bp)
+
+
+func visualize_phase(
+	pokemon: BattlePokemon,
+	ui: BattleUI,
+	phase: Phases,
+	ctx: BattlePhaseContext = null
+) -> void:
+	await super.visualize_phase(pokemon, ui, phase, ctx)
+	if phase != Phases.ON_END_BATTLE_TURN or has_finished():
+		_residual_targets.clear()
+		return
+	for bp in _residual_targets:
+		if bp == null or bp.is_fainted():
+			continue
+		var msg := ui.message_controller.get_weather_residual_damage_message(get_weather_id(), bp)
+		if not msg.is_empty():
+			await ui.show_message_from_dict(msg)
+		if bp.battle_spot != null:
+			await bp.battle_spot.apply_damage()
+	_residual_targets.clear()
+
+
+func get_priority() -> int:
+	return BattleEffectPriority.END_WEATHER_RESIDUAL
+
+
+func _get_active_pokemon() -> Array[BattlePokemon]:
+	var controller := BattleEffectController.get_instance()
+	if controller == null or controller.ui == null or controller.ui.battle_controller == null:
+		return []
+	return controller.ui.battle_controller.get_all_active_pokemon()
+
+
+func _is_immune_to_hail(pokemon: BattlePokemon) -> bool:
+	if _has_type(pokemon, TypesEnum.Values.ICE):
+		return true
+	if pokemon.ability == null:
+		return false
+	var ability_id := int(pokemon.ability.id)
+	return ability_id == MAGIC_GUARD_ABILITY_ID or ability_id == OVERCOAT_ABILITY_ID
+
+
+func _has_type(pokemon: BattlePokemon, type_id: int) -> bool:
+	var type1 := pokemon.get_type1()
+	if type1 != null and type1.id == type_id:
+		return true
+	var type2 := pokemon.get_type2()
+	return type2 != null and type2.id == type_id

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/HailWeatherEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/HailWeatherEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://d4hailweather01

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/RainWeatherEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/RainWeatherEffect.gd
@@ -1,36 +1,11 @@
-extends PersistentBattleEffect
 class_name RainWeatherEffect
+extends WeatherBattleEffect
 
-var started_by_move: bool = false  # Indica si fue iniciado por un movimiento (true) o es lluvia natural (false)
-
-func _init(_source = null, _duration: int = 5, _started_by_move: bool = false) -> void:
-	super._init(_source)
-	turns_left = _duration
-	started_by_move = _started_by_move
-
-func apply_phase(_pokemon: BattlePokemon, phase: Phases, _ctx: BattlePhaseContext = null) -> void:
-	if phase == Phases.ON_END_BATTLE_TURN and started_by_move:
-		next_turn()
-		# No eliminamos aquí: el BattleEffectController lo hace después de visualize_phase()
-
-func visualize_phase(_pokemon: BattlePokemon, ui: BattleUI, phase: Phases, _ctx: BattlePhaseContext = null) -> void:
-	if phase == Phases.ON_BATTLE_START:
-		await ui.show_message_from_dict(ui.message_controller.get_start_weather_message(source.id))
-	elif phase == Phases.ON_END_BATTLE_TURN:
-		if has_finished():
-			await ui.show_message_from_dict(ui.message_controller.get_end_weather_message(source.id))
-			return
-		await ui.show_message_from_dict(ui.message_controller.get_ongoing_weather_message(source.id))
 
 func on_power(move: BattleMove, _user, _target, value):
 	var move_type = move.get_type()
-	# Aumentar poder de movimientos Agua en 50%
 	if move_type.id == TypesEnum.Values.WATER:
 		return value * 1.5
-	# Reducir poder de movimientos Fuego en 50%
 	elif move_type.id == TypesEnum.Values.FIRE:
 		return value * 0.5
 	return value
-
-func get_priority() -> int:
-	return 5

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/SandstormWeatherEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/SandstormWeatherEffect.gd
@@ -1,0 +1,73 @@
+class_name SandstormWeatherEffect
+extends WeatherBattleEffect
+
+const MAGIC_GUARD_ABILITY_ID := 98
+const OVERCOAT_ABILITY_ID := 142
+
+var _residual_targets: Array[BattlePokemon] = []
+
+
+func _on_weather_tick(_pokemon: BattlePokemon, phase: Phases, _ctx: BattlePhaseContext = null) -> void:
+	if phase != Phases.ON_END_BATTLE_TURN or has_finished():
+		return
+	_residual_targets.clear()
+	for bp in _get_active_pokemon():
+		if bp.is_fainted() or _is_immune_to_sandstorm(bp):
+			continue
+		var dmg := ceili(bp.total_hp / 16.0)
+		var effect := DamageEffect.new(null, bp, null, dmg)
+		bp.take_damage(effect)
+		_residual_targets.append(bp)
+
+
+func visualize_phase(
+	pokemon: BattlePokemon,
+	ui: BattleUI,
+	phase: Phases,
+	ctx: BattlePhaseContext = null
+) -> void:
+	await super.visualize_phase(pokemon, ui, phase, ctx)
+	if phase != Phases.ON_END_BATTLE_TURN or has_finished():
+		_residual_targets.clear()
+		return
+	for bp in _residual_targets:
+		if bp == null or bp.is_fainted():
+			continue
+		var msg := ui.message_controller.get_weather_residual_damage_message(get_weather_id(), bp)
+		if not msg.is_empty():
+			await ui.show_message_from_dict(msg)
+		if bp.battle_spot != null:
+			await bp.battle_spot.apply_damage()
+	_residual_targets.clear()
+
+
+func get_priority() -> int:
+	return BattleEffectPriority.END_WEATHER_RESIDUAL
+
+
+func _get_active_pokemon() -> Array[BattlePokemon]:
+	var controller := BattleEffectController.get_instance()
+	if controller == null or controller.ui == null or controller.ui.battle_controller == null:
+		return []
+	return controller.ui.battle_controller.get_all_active_pokemon()
+
+
+func _is_immune_to_sandstorm(pokemon: BattlePokemon) -> bool:
+	if (
+		_has_type(pokemon, TypesEnum.Values.ROCK)
+		or _has_type(pokemon, TypesEnum.Values.GROUND)
+		or _has_type(pokemon, TypesEnum.Values.STEEL)
+	):
+		return true
+	if pokemon.ability == null:
+		return false
+	var ability_id := int(pokemon.ability.id)
+	return ability_id == MAGIC_GUARD_ABILITY_ID or ability_id == OVERCOAT_ABILITY_ID
+
+
+func _has_type(pokemon: BattlePokemon, type_id: int) -> bool:
+	var type1 := pokemon.get_type1()
+	if type1 != null and type1.id == type_id:
+		return true
+	var type2 := pokemon.get_type2()
+	return type2 != null and type2.id == type_id

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/SandstormWeatherEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/SandstormWeatherEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://d5sandstormw01

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/SunWeatherEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/SunWeatherEffect.gd
@@ -1,0 +1,11 @@
+class_name SunWeatherEffect
+extends WeatherBattleEffect
+
+
+func on_power(move: BattleMove, _user, _target, value):
+	var move_type = move.get_type()
+	if move_type.id == TypesEnum.Values.FIRE:
+		return value * 1.5
+	elif move_type.id == TypesEnum.Values.WATER:
+		return value * 0.5
+	return value

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/SunWeatherEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/SunWeatherEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://d7sunweather001

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/WeatherBattleEffect.gd
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/WeatherBattleEffect.gd
@@ -1,0 +1,74 @@
+class_name WeatherBattleEffect
+extends PersistentBattleEffect
+
+## Clima iniciado por movimiento (true) o clima natural del combate (false).
+var started_by_move: bool = false
+
+
+func _init(_source: WeatherData = null, _duration: int = 5, _started_by_move: bool = false) -> void:
+	super._init(_source)
+	turns_left = _duration
+	started_by_move = _started_by_move
+
+
+func get_weather_data() -> WeatherData:
+	return source as WeatherData
+
+
+func get_weather_id() -> int:
+	var data := get_weather_data()
+	return data.id if data != null else 0
+
+
+func apply_phase(pokemon: BattlePokemon, phase: Phases, ctx: BattlePhaseContext = null) -> void:
+	if phase == Phases.ON_END_BATTLE_TURN and _should_decrement_turns():
+		next_turn()
+		# No eliminamos aquí: BattleEffectController lo hace después de visualize_phase().
+	_on_weather_tick(pokemon, phase, ctx)
+	_apply_weather_effects_for_phase(pokemon, phase, ctx)
+
+
+func visualize_phase(pokemon: BattlePokemon, ui: BattleUI, phase: Phases, ctx: BattlePhaseContext = null) -> void:
+	await _show_weather_messages_for_phase(pokemon, ui, phase, ctx)
+
+
+func _should_decrement_turns() -> bool:
+	return started_by_move
+
+
+func _show_weather_messages_for_phase(
+	_pokemon: BattlePokemon,
+	ui: BattleUI,
+	phase: Phases,
+	_ctx: BattlePhaseContext = null
+) -> void:
+	var weather_id := get_weather_id()
+	if weather_id == 0:
+		return
+	if phase == Phases.ON_BATTLE_START:
+		await ui.show_message_from_dict(ui.message_controller.get_start_weather_message(weather_id))
+	elif phase == Phases.ON_END_BATTLE_TURN:
+		if has_finished():
+			await ui.show_message_from_dict(ui.message_controller.get_end_weather_message(weather_id))
+			return
+		await ui.show_message_from_dict(ui.message_controller.get_ongoing_weather_message(weather_id))
+
+
+func _apply_weather_effects_for_phase(
+	_pokemon: BattlePokemon,
+	_phase: Phases,
+	_ctx: BattlePhaseContext = null
+) -> void:
+	pass
+
+
+func _on_weather_tick(
+	_pokemon: BattlePokemon,
+	_phase: Phases,
+	_ctx: BattlePhaseContext = null
+) -> void:
+	pass
+
+
+func get_priority() -> int:
+	return 5

--- a/Scripts/Battle/core/Battle Effects/Persistent/Weather/WeatherBattleEffect.gd.uid
+++ b/Scripts/Battle/core/Battle Effects/Persistent/Weather/WeatherBattleEffect.gd.uid
@@ -1,0 +1,1 @@
+uid://c8k3m2weather01

--- a/Scripts/Battle/core/BattleEffectPriority.gd
+++ b/Scripts/Battle/core/BattleEffectPriority.gd
@@ -21,6 +21,7 @@ const VALIDATE_TRAP := 10
 ## ON_END_BATTLE_TURN — residuales y ticks.
 const END_POISON := 25
 const END_BURN := 24
+const END_WEATHER_RESIDUAL := 20
 const END_TRAP := 15
 const END_PERISH_SONG := 14
 const END_YAWN := 13
@@ -112,6 +113,8 @@ static func _end_turn_priority(effect_class: String) -> int:
 			return END_POISON
 		"BurnAilmentEffect":
 			return END_BURN
+		"HailWeatherEffect", "SandstormWeatherEffect":
+			return END_WEATHER_RESIDUAL
 		"TrapAilmentEffect":
 			return END_TRAP
 		"PerishSongAilmentEffect":

--- a/Scripts/Battle/core/Controllers/BattleEffectController.gd
+++ b/Scripts/Battle/core/Controllers/BattleEffectController.gd
@@ -41,6 +41,9 @@ static func add_field_effect(effect: PersistentBattleEffect):
 static func remove_field_effect(effect: PersistentBattleEffect):
 	get_instance()._remove_field_effect(effect)
 
+static func remove_field_weather_effects() -> void:
+	get_instance()._remove_field_weather_effects()
+
 static func has_effect_for(pokemon, effect_instance: PersistentBattleEffect) -> bool:
 	return effect_instance != null and get_instance()._has_effect_for(pokemon, effect_instance)
 
@@ -215,6 +218,13 @@ func _add_field_effect(effect: PersistentBattleEffect):
 func _remove_field_effect(effect: PersistentBattleEffect):
 	var target_class = effect.get_script().get_global_name()
 	field_effects = _filter_out_effect_class(field_effects, target_class)
+
+func _remove_field_weather_effects() -> void:
+	var kept := _empty_effect_list()
+	for effect in field_effects:
+		if not effect is WeatherBattleEffect:
+			kept.append(effect)
+	field_effects = kept
 
 func _has_effect_for(pokemon, effect: PersistentBattleEffect) -> bool:
 	var target_class = effect.get_script().get_global_name()

--- a/Scripts/Battle/core/Messages/BattleMessageWeather.gd
+++ b/Scripts/Battle/core/Messages/BattleMessageWeather.gd
@@ -52,7 +52,7 @@ func get_ongoing_weather_message(weather_id: int) -> Dictionary:
 			return {}
 
 	return {
-		"type": "wait",
+		"type": "display",
 		"text": msg,
 		"wait_time": 1.0
 	}
@@ -101,5 +101,4 @@ func get_residual_damage_message(weather_id: int, pokemon: BattlePokemon) -> Dic
 			msg = "¡La tormenta de arena daña a %s!" % pokemon.get_battle_display_name(true)
 		_:
 			return {}
-	return { "type": "wait", "text": msg, "wait_time": 1.0 }
-
+	return { "type": "display", "text": msg, "wait_time": 0.5 }

--- a/Scripts/Battle/core/Messages/BattleMessageWeather.gd
+++ b/Scripts/Battle/core/Messages/BattleMessageWeather.gd
@@ -88,4 +88,18 @@ func get_end_weather_message(weather_id: int) -> Dictionary:
 
 func get_already_active_weather_message() -> Dictionary:
 	return { "type": "wait", "text": "¡Pero falló!", "wait_time": 1.0 }
-	
+
+
+func get_residual_damage_message(weather_id: int, pokemon: BattlePokemon) -> Dictionary:
+	if pokemon == null:
+		return {}
+	var msg := ""
+	match weather_id:
+		WeathersEnum.Values.HAIL:
+			msg = "¡El granizo daña a %s!" % pokemon.get_battle_display_name(true)
+		WeathersEnum.Values.SANDSTORM:
+			msg = "¡La tormenta de arena daña a %s!" % pokemon.get_battle_display_name(true)
+		_:
+			return {}
+	return { "type": "wait", "text": msg, "wait_time": 1.0 }
+

--- a/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
+++ b/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
@@ -171,7 +171,7 @@ static func _format_effect_name(name: String) -> String:
 		return "Lluvia"
 	if name == "SunWeatherEffect":
 		return "Sol"
-	if name == "SandstormWeather":
+	if name == "SandstormWeatherEffect":
 		return "Tormenta de Arena"
 	if name == "HailWeatherEffect":
 		return "Granizo"

--- a/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
+++ b/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
@@ -167,9 +167,9 @@ static func apply_power_modifiers(move: BattleMove, user: BattlePokemon, target:
 # Convierte nombres de efectos de CamelCase a formato legible
 static func _format_effect_name(name: String) -> String:
 	# Casos especiales primero
-	if name == "RainWeather":
+	if name == "RainWeatherEffect":
 		return "Lluvia"
-	if name == "SunnyWeather":
+	if name == "SunWeatherEffect":
 		return "Sol"
 	if name == "SandstormWeather":
 		return "Tormenta de Arena"

--- a/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
+++ b/Scripts/Battle/core/Utils/DamageCalculator_Gen5.gd
@@ -173,7 +173,7 @@ static func _format_effect_name(name: String) -> String:
 		return "Sol"
 	if name == "SandstormWeather":
 		return "Tormenta de Arena"
-	if name == "HailWeather":
+	if name == "HailWeatherEffect":
 		return "Granizo"
 
 	# Para otros casos, intentar convertir de CamelCase

--- a/Scripts/Battle/ui/BattleMessageController.gd
+++ b/Scripts/Battle/ui/BattleMessageController.gd
@@ -299,6 +299,14 @@ func get_end_weather_message(weather_id: WeathersEnum.Values) -> Dictionary:
 func get_already_active_weather_message() -> Dictionary:
 	return WeatherMessages.get_already_active_weather_message()
 
+func get_weather_residual_damage_message(
+	weather_id: WeathersEnum.Values,
+	pokemon: BattlePokemon
+) -> Dictionary:
+	if weather_id == WeathersEnum.Values.NONE or pokemon == null:
+		return {}
+	return WeatherMessages.get_residual_damage_message(weather_id, pokemon)
+
 func get_start_field_effect_message(effect_id: FieldEffectsEnum.Values, side: BattleSide = null) -> Dictionary:
 	if effect_id < 0:
 		return {}

--- a/Scripts/Battle/ui/BattleUI.gd
+++ b/Scripts/Battle/ui/BattleUI.gd
@@ -130,6 +130,8 @@ func show_action_selection(pokemon: BattlePokemon) -> BattleChoice:
 		return choice
 
 	var move_choice: BattleMoveChoice = await show_move_selection(pokemon)
+	if move_choice.canceled:
+		return await show_action_selection(pokemon)
 
 	return move_choice
 
@@ -909,8 +911,9 @@ func show_move_selection(pokemon: BattlePokemon) -> BattleMoveChoice:
 	var move_choice = await show_moves_menu_for(pokemon)
 
 	if move_choice.canceled:
-		# Si el usuario cancela el menú de movimientos, se vuelve a mostrar el menú de acciones
-		return await show_action_selection(pokemon)
+		var canceled := BattleMoveChoice.new()
+		canceled.canceled = true
+		return canceled
 
 	return await _finish_move_selection(pokemon, move_choice)
 

--- a/Scripts/Resources/Classes/WeatherData.gd
+++ b/Scripts/Resources/Classes/WeatherData.gd
@@ -6,5 +6,5 @@ class_name WeatherData
 @export var display_name: String
 @export var effect: Resource
 
-func get_effect(_duration: int = 5, _started_by_move: bool = false) -> PersistentBattleEffect:
-	return effect.new(self,_duration,_started_by_move) if effect != null else null
+func get_effect(_duration: int = 5, _started_by_move: bool = false) -> WeatherBattleEffect:
+	return effect.new(self, _duration, _started_by_move) if effect != null else null


### PR DESCRIPTION
## Sistema de climas de combate ([AB#691](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/691), [AB#692](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/692), [AB#688](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/688), [AB#689](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/689), [AB#690](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/690))

### Resumen

Implementación del sistema de climas de combate con arquitectura común reutilizable. Cubre los 4 climas principales (Lluvia, Sol, Granizo y Tormenta de Arena), sus movimientos asociados, mensajes HGSS, daño residual y escenario de prueba en `TestBattle`.

---

### Arquitectura base

- **`WeatherBattleEffect`** — Clase base para efectos persistentes de clima:
  - Duración configurable (5 turnos si lo activa un movimiento)
  - Flag `started_by_move` (clima por movimiento vs. clima natural)
  - Hooks `_on_weather_tick` y `_apply_weather_effects_for_phase`
  - Mensajes automáticos de inicio, ongoing y fin de turno
- **`WeatherMoveEffect`** — Clase base para movimientos de clima:
  - Activación del clima en campo
  - Reemplazo del clima previo
  - Mensaje de fallo si el clima ya está activo (`¡Pero falló!`)
- **`WeatherData.get_effect()`** — Instancia el `WeatherBattleEffect` correspondiente desde el recurso `.tres`
- **`BattleEffectController.remove_field_weather_effects()`** — Elimina solo efectos de clima al cambiar de uno a otro

---

### Climas implementados

| PBI | Clima | Movimiento | Efecto |
|-----|-------|------------|--------|
| [AB#691](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/691)/692 | **Lluvia** | Danza Lluvia | AGUA ×1.5, FUEGO ×0.5 (`RainWeatherEffect`, refactor sobre lógica previa) |
| [AB#688](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/688) | **Sol** | Día Soleado | FUEGO ×1.5, AGUA ×0.5 (`SunWeatherEffect`) |
| [AB#689](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/689) | **Granizo** | Granizo | Daño residual 1/16 PS máx.; inmune: HIELO, Guardia Mágica (98), Caparazón (142) |
| [AB#690](https://dev.azure.com/AlberttRed/3064cbb4-71d2-40ad-ac00-28d16c60a797/_workitems/edit/690) | **Tormenta de Arena** | Tormenta Arena | Daño residual 1/16 PS máx.; inmune: ROCA/TIERRA/ACERO, Guardia Mágica, Caparazón |

---

### Mensajes y visualización

- Mensajes de clima en **`BattleMessageWeather.gd`** (inicio, ongoing, fin, ya activo, daño residual)
- **`BattleMessageController.get_weather_residual_damage_message()`** para daño residual
- Prioridad **`END_WEATHER_RESIDUAL = 20`** en `BattleEffectPriority` (antes de veneno/quemadura)
- Mensajes ongoing y de daño residual con `type: "display"` para mantener el panel visible durante la animación de la barra de PS
- Nombres de clima actualizados en **`DamageCalculator_Gen5`** para el log de modificadores de daño

---

### Recursos actualizados

- `Resources/Data/Weather/` — `RAIN.tres`, `SUN.tres`, `HAIL.tres`, `SANDSTORM.tres`
- `Resources/Data/Moves/` — `240 - Danza Lluvia`, `241 - Día Soleado`, `258 - Granizo`, `201 - Tormenta Arena`

---

### Escenario de prueba (`TestBattle`)

- Export **`use_rain_weather_test`** (grupo *Debug clima*, activo por defecto)
- **Jugador:** Squirtle Nv.30 — Granizo, Día Soleado, Pistola Agua, Tormenta Arena
- **Rival:** Pidgey Nv.30 — Tornado + Placaje
- Mochila de prueba con pociones y bolas al iniciar el escenario de clima

---

### Correcciones incluidas

- **UI de combate:** al cancelar el menú de movimientos (Luchar → atrás), ya no se rompe el flujo al usar la mochila después (`BattleUI.gd`)
- **Panel de mensajes:** el MessageBox ya no se oculta durante la animación de PS en daño residual de clima/ailments post-turno
